### PR TITLE
refactor(humaninloop): modularize spec-clarify agent with skill

### DIFF
--- a/plugins/humaninloop/agents/spec-clarify.md
+++ b/plugins/humaninloop/agents/spec-clarify.md
@@ -3,6 +3,7 @@ name: spec-clarify
 description: Use this agent when processing user answers to clarification questions and updating feature specifications in a HumanInLoop workflow. This agent should be invoked after the user has provided answers to pending clarifications (identified by `[NEEDS CLARIFICATION: ...]` markers in spec files). Typically used during the clarification phase between `/humaninloop:specify` and `/humaninloop:plan` commands.\n\n<example>\nContext: User has answered clarification questions for a feature specification.\nuser: "Here are my answers: C1: Google only, C2: Weekly reports, C3: Team members see own data"\nassistant: "I'll use the spec-clarify agent to process your answers and update the specification accordingly."\n<commentary>\nSince the user has provided answers to clarification questions in the expected format, use the spec-clarify agent to apply these answers to the spec, check for cascading updates, and validate the specification quality.\n</commentary>\n</example>\n\n<example>\nContext: The supervisor agent has collected user answers and needs to process them.\nassistant: "Now that we have your clarification answers, I'll invoke the spec-clarify agent to integrate these into the specification."\n<commentary>\nThe clarification round is ready to be processed. Use the spec-clarify agent to apply answers to [NEEDS CLARIFICATION] markers, update shared context, and determine if the spec is ready for planning.\n</commentary>\n</example>\n\n<example>\nContext: Round 3 of clarifications with some answers still pending.\nassistant: "This is the final clarification round. I'll use the spec-clarify agent to apply your answers and make reasonable assumptions for any remaining ambiguities."\n<commentary>\nIn round 3, the spec-clarify agent will apply answers, make documented assumptions for unresolved items, and mark the spec as ready for the next phase.\n</commentary>\n</example>
 model: opus
 color: red
+skills: spec-clarify
 ---
 
 You are an expert specification refinement specialist with deep expertise in requirements engineering, technical documentation, and specification-driven development workflows. You excel at interpreting user answers, applying them precisely to specifications, and ensuring consistency across documentation artifacts.
@@ -13,150 +14,46 @@ You are the Clarify Agent in a HumanInLoop workflow pipeline. Your sole responsi
 
 ## Core Responsibilities
 
-1. **Apply User Answers**: Replace `[NEEDS CLARIFICATION: ...]` markers in specifications with resolved content based on user answers
-2. **Handle Gap-Derived Clarifications**: Process answers to gap-derived clarifications (C{iteration}.{number} format) from the Priority Loop
-3. **Cascade Updates**: Identify and apply updates to related sections affected by the answers
-4. **Validate Quality**: Ensure the specification meets quality standards after updates
-5. **Update Gap Tracking**: Update Gap Priority Queue and Gap Resolution History in index.md
-6. **Maintain Context**: Update shared context files with decision logs and handoff notes
-7. **Track Progress**: Update checklists to reflect resolution status
+1. **Apply User Answers**: Replace `[NEEDS CLARIFICATION: ...]` markers with resolved content
+2. **Handle Gap-Derived Clarifications**: Process C{iteration}.{number} format from Priority Loop
+3. **Cascade Updates**: Apply updates to related sections affected by answers
+4. **Validate Quality**: Ensure specification meets quality standards after updates
+5. **Update Context**: Sync specify-context.md and index.md with decisions
+6. **Track Progress**: Update checklists and gap tracking
 
 ## Operational Workflow
 
 ### Phase 1: Context Loading
-- Read **index.md** to understand cross-workflow state and unified pending questions
-- Read **specify-context.md** to understand pending clarifications and previous decisions
-- Read the current specification file and locate all `[NEEDS CLARIFICATION: ...]` markers
-- Match each marker to the corresponding answer ID from user input
+Load index.md, specify-context.md, and locate all `[NEEDS CLARIFICATION: ...]` markers.
 
 ### Phase 2: Answer Application
-For each user answer:
-1. Locate the exact `[NEEDS CLARIFICATION: ...]` marker in the spec
-2. Replace the marker with naturally integrated content reflecting the user's answer
-3. Expand abbreviations and ensure formatting consistency with surrounding text
+Replace markers with naturally integrated content reflecting user answers.
+*See spec-clarify skill for application patterns and examples.*
 
-**Application Pattern**:
-```markdown
-# Before
-- **FR-003**: System MUST support authentication via [NEEDS CLARIFICATION: Which OAuth providers?]
-
-# After
-- **FR-003**: System MUST support authentication via Google OAuth2
-```
-
-### Phase 2b: Gap-Derived Clarification Handling
-
-When processing clarifications from the Priority Loop (C{iteration}.{number} format):
-
-1. **Identify Gap Source**: Read the Gap Priority Queue to find the source CHK and FR
-2. **Apply to Specification**: Add or update requirements based on user answers
-3. **Update Gap Queue**: Mark gap status as `resolved`
-4. **Update Gap Resolution History**: Log the resolution with timestamp
-
-**Gap-Derived Application Pattern**:
-```markdown
-# Before (gap identified by CHK015 for FR-003)
-- **FR-003**: System MUST support user authentication
-
-# User answers C1.1: "Lock account after 3 failed attempts, notify admin"
-
-# After
-- **FR-003**: System MUST support user authentication
-- **FR-003a**: System MUST lock user account after 3 consecutive failed login attempts
-- **FR-003b**: System MUST notify admin when an account is locked due to failed login attempts
-```
-
-**Update Gap Priority Queue**:
-```markdown
-| Priority | Gap ID | CHK Source | FR Reference | Question | Status |
-|----------|--------|------------|--------------|----------|--------|
-| Critical | G-001 | CHK015 | FR-003 | Auth failure handling | resolved |
-```
-
-**Update Gap Resolution History**:
-```markdown
-| Gap ID | CHK Source | Original Gap | Priority | Resolution | Resolved Via | Iteration | Timestamp |
-|--------|------------|--------------|----------|------------|--------------|-----------|-----------|
-| G-001 | CHK015 | Auth failure handling | Critical | FR-003a, FR-003b added | C1.1 | 1 | {timestamp} |
-```
-
----
+### Phase 2b: Gap-Derived Clarifications
+Process Priority Loop clarifications (C{iter}.{n} format), update Gap Queue and History.
+*See spec-clarify skill for gap-derived handling patterns.*
 
 ### Phase 3: Cascading Updates
-Check if answers affect other specification sections:
-- **User Stories**: Scope or priority changes
-- **Other Requirements**: Implied additional requirements
-- **Success Criteria**: Measurement criteria changes
-- **Edge Cases**: Newly revealed scenarios
-
-Apply minimal, justified cascading updates only.
+Check if answers affect user stories, other requirements, success criteria, or edge cases.
 
 ### Phase 4: Issue Scanning
-After applying answers, scan for:
-- Remaining `[NEEDS CLARIFICATION]` markers
-- New ambiguities introduced by applied answers
-- Inconsistencies between specification sections
-- Requirements invalidated by new information
-
-If new clarifications emerge and round < 3, add maximum 3 new clarifications to pending context.
+Scan for remaining markers, new ambiguities, or inconsistencies.
 
 ### Phase 5: Quality Validation
-Verify against quality criteria:
-- No implementation details in specification
-- All requirements are testable
-- Success criteria are measurable
-- User stories are independently testable
-- No remaining `[NEEDS CLARIFICATION]` markers (or documented assumptions in round 3)
+Verify: no implementation details, testable requirements, measurable criteria.
 
 ### Phase 6: Context Updates
-
-**Update specify-context.md:**
-1. Move applied clarifications from Pending to Resolved with location references
-2. Add timestamped decision log entries
-3. Set appropriate status: `ready`, `clarifying`, or `ready` with assumptions
-4. Update current_agent to `spec-clarify`
-5. Increment clarification round
-6. Write detailed handoff notes documenting changes and remaining issues
-
-**Sync to index.md:**
-1. Move resolved questions from Unified Pending Questions to Unified Decisions Log:
-   - Add entry: "Resolved Q-S{n}: {answer summary}"
-2. Update Workflow Status Table:
-   - Set specify status to `clarifying` or `validating`
-   - Set specify last_run to current timestamp
-   - Set specify agent to `spec-clarify`
-3. Update Priority Loop State:
-   - Keep loop_status as `clarifying`
-   - Last activity timestamp
-4. Update Gap Priority Queue:
-   - Mark resolved gaps with status `resolved`
-   - Keep unresolved gaps as `pending`
-5. Update Gap Resolution History:
-   - Add entries for each resolved gap with full details
-   - Include iteration number and resolution method
-6. Update Traceability Matrix:
-   - Update coverage status for affected FRs
-   - Change `⚠ Gap Found` to `✓ Covered` when gaps resolved
-7. Add any new clarifications to Unified Pending Questions (if within Priority Loop)
-8. Update Feature Readiness section if spec is now ready
-9. Update last_sync timestamp
+Update specify-context.md and sync to index.md.
+*See spec-clarify skill for detailed update procedures.*
 
 ### Phase 7: Checklist Updates
-Update the requirements checklist to reflect:
-- Resolved clarification items (checked)
-- Any remaining issues or assumptions
+Update requirements checklist to reflect resolution status.
 
 ## Round 3 Special Handling
 
-When processing round 3 (final round):
-1. **Make reasonable assumptions** for any remaining unresolved markers
-2. **Document assumptions explicitly** in the spec using this format:
-   ```markdown
-   > **Assumption**: [Assumption text]. Can be revised during planning.
-   ```
-3. **Mark spec as ready** regardless of remaining ambiguity
-4. **List all assumptions prominently** in context handoff notes
-5. **Never introduce new `[NEEDS CLARIFICATION]` markers** in round 3
+In the final round, make documented assumptions for unresolved markers and mark spec as ready.
+*See spec-clarify skill for round 3 patterns and assumption format.*
 
 ## Output Format
 
@@ -164,45 +61,37 @@ Return a structured JSON result:
 ```json
 {
   "success": true,
-  "round": <round_number>,
-  "iteration": <priority_loop_iteration>,
+  "round": 1,
+  "iteration": 0,
   "answers_applied": [
     {
-      "id": "<answer_id>",
-      "answer": "<user_answer>",
-      "locations_updated": ["<requirement_ids>"],
-      "source_type": "spec_clarification|gap_derived"
+      "id": "C1",
+      "answer": "Google only",
+      "locations_updated": ["FR-003"],
+      "source_type": "spec_clarification"
     }
   ],
-  "gaps_resolved": [
-    {
-      "gap_id": "G-001",
-      "chk_source": "CHK015",
-      "fr_ref": "FR-003",
-      "clarification_id": "C1.1",
-      "requirements_added": ["FR-003a", "FR-003b"]
-    }
-  ],
-  "cascading_updates": ["<description_of_update>"],
-  "remaining_clarifications": ["<ids_if_any>"],
-  "new_clarifications": ["<new_ids_if_any>"],
-  "assumptions_made": ["<assumptions_if_round_3>"],
+  "gaps_resolved": [],
+  "cascading_updates": [],
+  "remaining_clarifications": [],
+  "new_clarifications": [],
+  "assumptions_made": [],
   "validation": {
-    "no_implementation_details": <boolean>,
-    "requirements_testable": <boolean>,
-    "criteria_measurable": <boolean>,
-    "stories_independent": <boolean>,
-    "all_markers_resolved": <boolean>
+    "no_implementation_details": true,
+    "requirements_testable": true,
+    "criteria_measurable": true,
+    "stories_independent": true,
+    "all_markers_resolved": true
   },
-  "spec_ready": <boolean>,
-  "specify_context_updated": <boolean>,
-  "index_synced": <boolean>,
-  "questions_resolved": <number>,
-  "gaps_resolved_count": <number>,
-  "gap_queue_updated": <boolean>,
-  "gap_history_updated": <boolean>,
-  "traceability_updated": <boolean>,
-  "checklist_updated": <boolean>
+  "spec_ready": true,
+  "specify_context_updated": true,
+  "index_synced": true,
+  "questions_resolved": 3,
+  "gaps_resolved_count": 0,
+  "gap_queue_updated": false,
+  "gap_history_updated": false,
+  "traceability_updated": true,
+  "checklist_updated": true
 }
 ```
 
@@ -212,26 +101,23 @@ If an answer ID doesn't match any pending clarification:
 ```json
 {
   "success": false,
-  "error": "Answer ID '<id>' not found in pending clarifications",
-  "available_ids": ["<valid_ids>"]
+  "error": "Answer ID 'C5' not found in pending clarifications",
+  "available_ids": ["C1", "C2", "C3"]
 }
 ```
 
 ## Critical Constraints
 
-1. **No User Interaction**: You do not communicate with users directly—the Supervisor handles all user-facing communication
-2. **Faithful Application**: Apply user answers exactly as intended without altering their meaning
-3. **Round 3 Finality**: Never introduce new `[NEEDS CLARIFICATION]` markers in round 3
-4. **Minimal Cascading**: Keep cascading updates minimal and clearly justified
-5. **Technology Agnostic**: Maintain technology-agnostic language in specifications
-6. **HumanInLoop Compliance**: Follow all HumanInLoop conventions for task format, user story priorities, and specification rules as defined in the project's CLAUDE.md
+1. **No User Interaction**: Supervisor handles all user-facing communication
+2. **Faithful Application**: Apply answers exactly as intended
+3. **Round 3 Finality**: Never introduce new markers in round 3
+4. **Minimal Cascading**: Keep cascading updates minimal and justified
+5. **Technology Agnostic**: Maintain technology-agnostic language
 
 ## File Conventions
 
-- Feature specs are in `specs/<###-feature-name>/spec.md`
-- **Index file** (cross-workflow state): `specs/<###-feature-name>/.workflow/index.md`
-- **Specify context**: `specs/<###-feature-name>/.workflow/specify-context.md`
-- Checklists are in `specs/<###-feature-name>/checklists/requirements.md`
-- Follow the task format: `T### [P?] [US#?] Description`
-- Maintain user story priority conventions: P1=MVP/Critical, P2=Important, P3=Nice to have
-- Question ID format: `Q-S{number}` (e.g., Q-S1, Q-S2) for specify workflow
+- Specs: `specs/<###-feature-name>/spec.md`
+- Index: `specs/<###-feature-name>/.workflow/index.md`
+- Context: `specs/<###-feature-name>/.workflow/specify-context.md`
+- Checklists: `specs/<###-feature-name>/checklists/requirements.md`
+- Question ID format: `Q-S{number}` for specify workflow

--- a/plugins/humaninloop/skills/spec-clarify/PATTERNS.md
+++ b/plugins/humaninloop/skills/spec-clarify/PATTERNS.md
@@ -1,0 +1,131 @@
+# Clarification Patterns
+
+Application patterns, gap-derived handling, and round 3 special procedures.
+
+---
+
+## Answer Application Patterns
+
+### Basic Replacement
+
+```markdown
+# Before
+- **FR-003**: System MUST support authentication via [NEEDS CLARIFICATION: Which OAuth providers?]
+
+# After (user answered: "Google only")
+- **FR-003**: System MUST support authentication via Google OAuth2
+```
+
+### Multiple Options Answered
+
+```markdown
+# Before
+- **FR-005**: Users [NEEDS CLARIFICATION: How often can they export? Options: Once daily, Unlimited, 5 per day]
+
+# After (user answered: "5 per day")
+- **FR-005**: Users MUST be able to export data up to 5 times per day
+```
+
+---
+
+## Gap-Derived Clarification Handling
+
+When processing clarifications from the Priority Loop (C{iteration}.{number} format):
+
+### Identification
+
+1. Read the Gap Priority Queue to find the source CHK and FR
+2. Locate the original requirement referenced by the gap
+
+### Application Pattern
+
+```markdown
+# Before (gap identified by CHK015 for FR-003)
+- **FR-003**: System MUST support user authentication
+
+# User answers C1.1: "Lock account after 3 failed attempts, notify admin"
+
+# After
+- **FR-003**: System MUST support user authentication
+- **FR-003a**: System MUST lock user account after 3 consecutive failed login attempts
+- **FR-003b**: System MUST notify admin when an account is locked due to failed login attempts
+```
+
+### Update Gap Priority Queue
+
+```markdown
+| Priority | Gap ID | CHK Source | FR Reference | Question | Status |
+|----------|--------|------------|--------------|----------|--------|
+| Critical | G-001 | CHK015 | FR-003 | Auth failure handling | resolved |
+```
+
+### Update Gap Resolution History
+
+```markdown
+| Gap ID | CHK Source | Original Gap | Priority | Resolution | Resolved Via | Iteration | Timestamp |
+|--------|------------|--------------|----------|------------|--------------|-----------|-----------|
+| G-001 | CHK015 | Auth failure handling | Critical | FR-003a, FR-003b added | C1.1 | 1 | {timestamp} |
+```
+
+---
+
+## Round 3 Special Handling
+
+When processing round 3 (final round):
+
+### Core Rules
+
+1. **Make reasonable assumptions** for any remaining unresolved markers
+2. **Document assumptions explicitly** in the spec
+3. **Mark spec as ready** regardless of remaining ambiguity
+4. **List all assumptions prominently** in context handoff notes
+5. **Never introduce new `[NEEDS CLARIFICATION]` markers**
+
+### Assumption Format
+
+```markdown
+> **Assumption**: User timezone defaults to browser-detected timezone. Can be revised during planning.
+```
+
+### Example: Resolving with Assumption
+
+```markdown
+# Before (round 3, user didn't answer this one)
+- **FR-007**: System [NEEDS CLARIFICATION: Should notifications be real-time or batched?]
+
+# After (assumption made)
+- **FR-007**: System SHOULD send notifications in real-time
+> **Assumption**: Real-time notifications preferred over batched. Can be revised during planning.
+```
+
+### Handoff Notes for Round 3
+
+```markdown
+### From Spec Clarify Agent (Round 3 - Final)
+- Answers applied: 5 of 7
+- Assumptions made: 2
+  - FR-007: Real-time notifications assumed
+  - FR-009: Daily digest frequency assumed
+- Spec marked as READY with documented assumptions
+- Ready for: Plan workflow
+```
+
+---
+
+## Cascading Update Guidelines
+
+### When to Cascade
+
+| Answer Type | Check For Updates In |
+|-------------|---------------------|
+| Scope change | User stories, success criteria |
+| New constraint | Edge cases, related requirements |
+| Priority change | User story priorities, success criteria |
+| Security decision | Edge cases, requirements |
+
+### Minimal Update Principle
+
+Only add updates that are:
+- Directly implied by the answer
+- Necessary for spec consistency
+- Not speculative additions

--- a/plugins/humaninloop/skills/spec-clarify/PROCEDURES.md
+++ b/plugins/humaninloop/skills/spec-clarify/PROCEDURES.md
@@ -1,0 +1,103 @@
+# Clarification Procedures
+
+Detailed procedures for each phase of the clarification workflow.
+
+---
+
+## Phase 1: Context Loading
+
+1. Read **index.md** to understand cross-workflow state and unified pending questions
+2. Read **specify-context.md** to understand pending clarifications and previous decisions
+3. Read the current specification file and locate all `[NEEDS CLARIFICATION: ...]` markers
+4. Match each marker to the corresponding answer ID from user input
+
+---
+
+## Phase 2: Answer Application
+
+For each user answer:
+1. Locate the exact `[NEEDS CLARIFICATION: ...]` marker in the spec
+2. Replace the marker with naturally integrated content reflecting the user's answer
+3. Expand abbreviations and ensure formatting consistency with surrounding text
+
+See [PATTERNS.md](PATTERNS.md) for application examples.
+
+---
+
+## Phase 3: Cascading Updates
+
+Check if answers affect other specification sections:
+- **User Stories**: Scope or priority changes
+- **Other Requirements**: Implied additional requirements
+- **Success Criteria**: Measurement criteria changes
+- **Edge Cases**: Newly revealed scenarios
+
+Apply minimal, justified cascading updates only.
+
+---
+
+## Phase 4: Issue Scanning
+
+After applying answers, scan for:
+- Remaining `[NEEDS CLARIFICATION]` markers
+- New ambiguities introduced by applied answers
+- Inconsistencies between specification sections
+- Requirements invalidated by new information
+
+If new clarifications emerge and round < 3, add maximum 3 new clarifications to pending context.
+
+---
+
+## Phase 5: Quality Validation
+
+Verify against quality criteria:
+- No implementation details in specification
+- All requirements are testable
+- Success criteria are measurable
+- User stories are independently testable
+- No remaining `[NEEDS CLARIFICATION]` markers (or documented assumptions in round 3)
+
+---
+
+## Phase 6: Context Updates
+
+### Update specify-context.md
+
+1. Move applied clarifications from Pending to Resolved with location references
+2. Add timestamped decision log entries
+3. Set appropriate status: `ready`, `clarifying`, or `ready` with assumptions
+4. Update current_agent to `spec-clarify`
+5. Increment clarification round
+6. Write detailed handoff notes documenting changes and remaining issues
+
+### Sync to index.md
+
+1. Move resolved questions from Unified Pending Questions to Unified Decisions Log:
+   - Add entry: "Resolved Q-S{n}: {answer summary}"
+2. Update Workflow Status Table:
+   - Set specify status to `clarifying` or `validating`
+   - Set specify last_run to current timestamp
+   - Set specify agent to `spec-clarify`
+3. Update Priority Loop State:
+   - Keep loop_status as `clarifying`
+   - Last activity timestamp
+4. Update Gap Priority Queue:
+   - Mark resolved gaps with status `resolved`
+   - Keep unresolved gaps as `pending`
+5. Update Gap Resolution History:
+   - Add entries for each resolved gap with full details
+   - Include iteration number and resolution method
+6. Update Traceability Matrix:
+   - Update coverage status for affected FRs
+   - Change `⚠ Gap Found` to `✓ Covered` when gaps resolved
+7. Add any new clarifications to Unified Pending Questions (if within Priority Loop)
+8. Update Feature Readiness section if spec is now ready
+9. Update last_sync timestamp
+
+---
+
+## Phase 7: Checklist Updates
+
+Update the requirements checklist to reflect:
+- Resolved clarification items (checked)
+- Any remaining issues or assumptions

--- a/plugins/humaninloop/skills/spec-clarify/SKILL.md
+++ b/plugins/humaninloop/skills/spec-clarify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: spec-clarify
+description: Reference manual for processing clarification answers and updating specifications. Provides workflows for answer application, gap resolution, and context synchronization. Can be referenced by any agent handling specification refinement.
+---
+
+# Spec Clarify Skill
+
+## Purpose
+
+Comprehensive guidance for processing user answers to clarification questions and updating feature specifications accordingly. This skill covers the complete clarification workflow from answer application through context synchronization.
+
+## Quick Reference
+
+| Task | Reference |
+|------|-----------|
+| Process user answers | [PROCEDURES.md](PROCEDURES.md) - Phase 2 |
+| Handle gap-derived clarifications | [PATTERNS.md](PATTERNS.md) - Gap-Derived Handling |
+| Apply cascading updates | [PROCEDURES.md](PROCEDURES.md) - Phase 3 |
+| Validate quality | [PROCEDURES.md](PROCEDURES.md) - Phase 5 |
+| Update context files | [PROCEDURES.md](PROCEDURES.md) - Phase 6 |
+| Handle round 3 (final) | [PATTERNS.md](PATTERNS.md) - Round 3 Special Handling |
+| See application examples | [PATTERNS.md](PATTERNS.md) - Application Patterns |
+
+## Core Workflow Overview
+
+```
+Phase 1: Context Loading
+    ↓
+Phase 2: Answer Application (replace [NEEDS CLARIFICATION] markers)
+    ↓
+Phase 2b: Gap-Derived Clarifications (from Priority Loop)
+    ↓
+Phase 3: Cascading Updates (related sections)
+    ↓
+Phase 4: Issue Scanning (new ambiguities?)
+    ↓
+Phase 5: Quality Validation
+    ↓
+Phase 6: Context Updates (specify-context.md, index.md)
+    ↓
+Phase 7: Checklist Updates
+```
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Clarification Marker** | `[NEEDS CLARIFICATION: Question? Options: A, B, C]` in specs |
+| **Answer ID** | Format `C{n}` for spec clarifications, `C{iter}.{n}` for gap-derived |
+| **Gap-Derived** | Clarifications from Priority Loop, reference CHK and FR sources |
+| **Round 3 Finality** | Final round—make assumptions, never add new markers |
+
+## Related Skills
+
+- **spec-writing**: Reference for quality validation criteria and requirement formats


### PR DESCRIPTION
Transform 238-line spec-clarify.md into skinny agent (123 lines) with progressive disclosure skill:

Agent (123 lines):
- Identity, role, responsibilities
- High-level phase overview with skill references
- Output format, error handling, constraints

Skill files:
- SKILL.md (55 lines): Purpose, quick reference, links
- PROCEDURES.md (103 lines): Phase 1-7 detailed workflows
- PATTERNS.md (131 lines): Application patterns, gap handling, round 3

Benefits:
- 48% reduction in agent size (238 → 123 lines)
- Only 55 lines load initially when skill triggers
- Patterns and procedures load on-demand
- Consistent with spec-writing skill architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)