### PR TITLE
fix: standardize skill descriptions to third-person format

### DIFF
--- a/plugins/humaninloop/skills/analysis-codebase/SKILL.md
+++ b/plugins/humaninloop/skills/analysis-codebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analysis-codebase
-description: Analyze existing codebases for tech stack, conventions, entities, and patterns. Use when scanning projects for context, brownfield analysis, or when you see "tech stack", "codebase analysis", "existing code", "collision risk", "brownfield", or "project context".
+description: This skill should be used when the user asks to "analyze codebase", "scan project", "detect tech stack", or mentions "codebase analysis", "existing code", "collision risk", "brownfield", or "project context". Provides systematic extraction of tech stack, conventions, entities, and patterns from existing codebases.
 ---
 
 # Analyzing Codebase

--- a/plugins/humaninloop/skills/analysis-specifications/SKILL.md
+++ b/plugins/humaninloop/skills/analysis-specifications/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analysis-specifications
-description: Review specifications to find gaps and generate clarifying questions. Use when reviewing spec.md, finding missing requirements, identifying ambiguities, or when you see "review spec", "find gaps", "what's missing", or "clarify requirements". Focuses on product decisions, not implementation details.
+description: This skill should be used when the user asks to "review spec", "find gaps", "what's missing", or "clarify requirements", or when reviewing spec.md for completeness. Focuses on product decisions, not implementation details. Generates clarifying questions with concrete options.
 ---
 
 # Reviewing Specifications

--- a/plugins/humaninloop/skills/authoring-constitution/SKILL.md
+++ b/plugins/humaninloop/skills/authoring-constitution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-constitution
-description: Write enforceable, testable constitution content with proper principle structure, section templates, and RFC 2119 keywords. Use when creating constitutions, writing principles, defining governance, or when you see "constitution", "governance", "principles", "enforcement", or "amendment process". Core skill for greenfield projects.
+description: This skill should be used when the user asks to "create constitution", "write principles", "define governance", or mentions "constitution", "governance", "principles", "enforcement", or "amendment process". Core skill for greenfield projects. Produces enforceable, testable constitution content with RFC 2119 keywords.
 ---
 
 # Authoring Constitution

--- a/plugins/humaninloop/skills/authoring-requirements/SKILL.md
+++ b/plugins/humaninloop/skills/authoring-requirements/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-requirements
-description: Write functional requirements using FR-XXX format with RFC 2119 keywords (MUST, SHOULD, MAY), success criteria (SC-XXX), and edge case identification. Use when writing requirements, specifications, success criteria, or when you see "functional requirements", "FR-", "SC-", "RFC 2119", "MUST SHOULD MAY", or "edge cases".
+description: This skill should be used when the user asks to "write requirements", "define success criteria", "identify edge cases", or mentions "functional requirements", "FR-", "SC-", "RFC 2119", "MUST SHOULD MAY", or "edge cases". Produces technology-agnostic requirements in FR-XXX format with measurable success criteria.
 ---
 
 # Authoring Requirements

--- a/plugins/humaninloop/skills/authoring-roadmap/SKILL.md
+++ b/plugins/humaninloop/skills/authoring-roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-roadmap
-description: Create evolution roadmaps with prioritized gap cards for brownfield projects. Use when generating gap analysis, identifying improvement priorities, or when you see "roadmap", "gap analysis", "evolution plan", "improvement priorities", or "brownfield gaps".
+description: This skill should be used when the user asks to "create roadmap", "generate gap analysis", "identify improvement priorities", or mentions "roadmap", "gap analysis", "evolution plan", "improvement priorities", or "brownfield gaps". Produces prioritized gap cards with dependencies for incremental codebase improvement.
 ---
 
 # Authoring Evolution Roadmap

--- a/plugins/humaninloop/skills/authoring-user-stories/SKILL.md
+++ b/plugins/humaninloop/skills/authoring-user-stories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-user-stories
-description: Write user stories with P1/P2/P3 priorities, Given/When/Then acceptance scenarios, and independent tests. Use when writing user stories, feature specifications, acceptance criteria, or when you see "user story", "acceptance scenario", "Given When Then", "priority", "P1", "P2", or "P3".
+description: This skill should be used when the user asks to "write user stories", "define acceptance criteria", "prioritize features", or mentions "user story", "acceptance scenario", "Given When Then", "priority", "P1", "P2", or "P3". Produces prioritized user stories with independently testable acceptance scenarios.
 ---
 
 # Authoring User Stories

--- a/plugins/humaninloop/skills/brownfield-constitution/SKILL.md
+++ b/plugins/humaninloop/skills/brownfield-constitution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brownfield-constitution
-description: Write constitutions for existing codebases using Essential Floor + Emergent Ceiling approach. Use when creating constitutions for brownfield projects, codifying existing patterns, or when you see "brownfield", "existing codebase", "essential floor", "emergent ceiling", or "evolution roadmap". Extends authoring-constitution skill.
+description: This skill should be used when the user asks to "create constitution for existing codebase", "codify existing patterns", or mentions "brownfield", "existing codebase", "essential floor", "emergent ceiling", or "evolution roadmap". Extends authoring-constitution with Essential Floor + Emergent Ceiling approach.
 ---
 
 # Brownfield Constitution Authoring

--- a/plugins/humaninloop/skills/patterns-api-contracts/SKILL.md
+++ b/plugins/humaninloop/skills/patterns-api-contracts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patterns-api-contracts
-description: RESTful API design following best practices with endpoint mapping, schema definition, and error handling. Use when mapping endpoints, defining schemas, or when you see "API", "endpoint", "REST", "OpenAPI", "schema", "contract", or "HTTP".
+description: This skill should be used when the user asks to "design API", "map endpoints", "define schemas", or mentions "API", "endpoint", "REST", "OpenAPI", "schema", "contract", or "HTTP". Provides RESTful API design with endpoint mapping, request/response schemas, and comprehensive error handling.
 ---
 
 # Designing API Contracts

--- a/plugins/humaninloop/skills/patterns-entity-modeling/SKILL.md
+++ b/plugins/humaninloop/skills/patterns-entity-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patterns-entity-modeling
-description: DDD-style entity modeling from requirements including extraction, attributes, relationships, and state machines. Use when extracting entities, defining attributes, modeling relationships, or when you see "entity", "data model", "relationship", "cardinality", "domain model", or "state machine".
+description: This skill should be used when the user asks to "extract entities", "define data model", "model relationships", or mentions "entity", "data model", "relationship", "cardinality", "domain model", or "state machine". Provides DDD-style entity modeling including attributes, relationships, and state machines.
 ---
 
 # Modeling Domain Entities

--- a/plugins/humaninloop/skills/patterns-technical-decisions/SKILL.md
+++ b/plugins/humaninloop/skills/patterns-technical-decisions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patterns-technical-decisions
-description: Evaluate technology alternatives and document decisions in ADR format. Use when making technology choices, comparing options, documenting decisions, or when you see "technology choice", "alternatives", "trade-offs", "decision record", "rationale", "why we chose", or "NEEDS CLARIFICATION".
+description: This skill should be used when the user asks to "evaluate alternatives", "make technology choice", "document decision", or mentions "technology choice", "alternatives", "trade-offs", "decision record", "rationale", "why we chose", or "NEEDS CLARIFICATION". Provides evaluation framework and ADR documentation format.
 ---
 
 # Making Technical Decisions

--- a/plugins/humaninloop/skills/patterns-vertical-tdd/SKILL.md
+++ b/plugins/humaninloop/skills/patterns-vertical-tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: patterns-vertical-tdd
-description: Structure implementation tasks using vertical slicing with TDD discipline. Use when creating task mappings, generating implementation tasks, or when you see "vertical slice", "TDD", "test first", "cycle structure", or "testable increment".
+description: This skill should be used when the user asks to "create task mapping", "structure implementation", "define cycles", or mentions "vertical slice", "TDD", "test first", "cycle structure", or "testable increment". Transforms requirements into vertical slices with strict test-first task ordering.
 ---
 
 # Vertical Slicing with TDD

--- a/plugins/humaninloop/skills/syncing-claude-md/SKILL.md
+++ b/plugins/humaninloop/skills/syncing-claude-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: syncing-claude-md
-description: Ensure CLAUDE.md mirrors constitution sections per explicit mapping. Use when synchronizing CLAUDE.md with constitution, validating alignment, or when you see "CLAUDE.md sync", "agent instructions", or need to propagate constitution changes to CLAUDE.md.
+description: This skill should be used when the user asks to "sync CLAUDE.md", "update agent instructions", "propagate constitution changes", or mentions "CLAUDE.md sync", "agent instructions", or "constitution alignment". Ensures CLAUDE.md mirrors constitution sections per explicit mapping rules.
 ---
 
 # Syncing CLAUDE.md

--- a/plugins/humaninloop/skills/validation-constitution/SKILL.md
+++ b/plugins/humaninloop/skills/validation-constitution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validation-constitution
-description: Validate constitution quality with checklists, anti-pattern detection, and version bump rules. Use after writing constitution content, when reviewing constitutions, or when you see "constitution review", "quality check", "version bump", "anti-patterns", or "constitution audit".
+description: This skill should be used when the user asks to "review constitution", "validate principles", "check quality", or mentions "constitution review", "quality check", "version bump", "anti-patterns", or "constitution audit". Provides checklists, anti-pattern detection, and version bump guidance.
 ---
 
 # Validating Constitution

--- a/plugins/humaninloop/skills/validation-plan-artifacts/SKILL.md
+++ b/plugins/humaninloop/skills/validation-plan-artifacts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validation-plan-artifacts
-description: Review planning artifacts (research, data model, contracts) for quality and completeness. Use when reviewing plan phase outputs, finding gaps in design decisions, or when you see "review research", "review data model", "review contracts", "plan quality", or "phase review".
+description: This skill should be used when the user asks to "review research", "review data model", "review contracts", or mentions "plan quality", "phase review", or "design gaps". Provides phase-specific review criteria for planning artifacts with issue classification.
 ---
 
 # Reviewing Plan Artifacts

--- a/plugins/humaninloop/skills/validation-task-artifacts/SKILL.md
+++ b/plugins/humaninloop/skills/validation-task-artifacts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validation-task-artifacts
-description: Review task artifacts (task-mapping, tasks.md) for quality and completeness. Use when reviewing task phase outputs, finding gaps in task planning, or when you see "review mapping", "review tasks", "task quality", or "cycle review".
+description: This skill should be used when the user asks to "review task mapping", "review tasks", "validate cycles", or mentions "task quality", "cycle review", or "TDD structure". Provides phase-specific review criteria for task artifacts with issue classification.
 ---
 
 # Reviewing Task Artifacts


### PR DESCRIPTION
- All 15 skill descriptions now use 'This skill should be used when...'

- Trigger phrases quoted per official skill development guide

- Aligns with claude-plugins-official/plugin-dev/skills/skill-development