### PR TITLE
fix(humaninloop): bring analysis-codebase and syncing-claude-md skills into guideline compliance

### DIFF
--- a/plugins/humaninloop/skills/analysis-codebase/SKILL.md
+++ b/plugins/humaninloop/skills/analysis-codebase/SKILL.md
@@ -1,17 +1,40 @@
 ---
 name: analysis-codebase
-description: This skill should be used when the user asks to "analyze codebase", "scan project", "detect tech stack", or mentions "codebase analysis", "existing code", "collision risk", "brownfield", or "project context". Provides systematic extraction of tech stack, conventions, entities, and patterns from existing codebases.
+description: Use when user asks to "analyze codebase", "scan project", "detect tech stack", or mentions "codebase analysis", "existing code", "collision risk", "brownfield", or "project context".
 ---
 
 # Analyzing Codebase
 
-## Purpose
+## Overview
 
-Systematically analyze existing codebases to extract structural information. Supports three modes:
+Systematically analyze existing codebases to extract structural information. Supports three modes: Context (project characteristics), Brownfield (entities and collision risks), and Setup-Brownfield (comprehensive analysis for `/humaninloop:setup`).
 
-1. **Context Mode**: Gather project characteristics to inform constitution authoring
-2. **Brownfield Mode**: Extract entities, endpoints, and collision risks for planning
-3. **Setup-Brownfield Mode**: Comprehensive analysis for `/humaninloop:setup` producing codebase-analysis.md
+## When to Use
+
+- Setting up constitution on existing codebase (brownfield projects)
+- Planning new features against existing code
+- Understanding tech stack before making changes
+- Detecting collision risks for new entities or endpoints
+- Running `/humaninloop:setup` on projects with existing code
+- Gathering project context for governance decisions
+
+## When NOT to Use
+
+- **Greenfield projects**: No existing code to analyze; start with `humaninloop:authoring-constitution` directly
+- **Single-file scripts**: No architectural patterns to extract
+- **Documentation-only review**: Use standard file reading instead
+- **Before project directory exists**: Nothing to analyze yet
+- **When user provides complete context**: Skip analysis if user already documented tech stack and patterns
+
+## Common Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Assuming framework | Guessing without evidence | Verify with code patterns |
+| Missing directories | Only checking standard paths | Projects vary, explore |
+| Over-extracting | Analyzing every file | Focus on config and patterns |
+| Ignoring governance | Missing existing decisions | Check README, CLAUDE.md, ADRs |
+| Inventing findings | Documenting assumptions | Only report what is found |
 
 ## Mode Selection
 
@@ -297,12 +320,8 @@ Before finalizing analysis:
 - [ ] Strengths and inconsistencies documented
 - [ ] Output written to `.humaninloop/memory/codebase-analysis.md`
 
-## Anti-Patterns
+## Related Skills
 
-| Anti-Pattern | Problem | Fix |
-|--------------|---------|-----|
-| **Assuming framework** | Guessing without evidence | Verify with code patterns |
-| **Missing directories** | Only checking standard paths | Projects vary, explore |
-| **Over-extracting** | Analyzing every file | Focus on config and patterns |
-| **Ignoring governance** | Missing existing decisions | Check README, CLAUDE.md, ADRs |
-| **Inventing findings** | Documenting assumptions | Only report what's found |
+- **For brownfield constitutions**: **REQUIRED:** Use humaninloop:brownfield-constitution after analysis
+- **For greenfield projects**: **OPTIONAL:** Use humaninloop:authoring-constitution directly
+- **For validation**: **OPTIONAL:** Use humaninloop:validation-constitution after constitution creation

--- a/plugins/humaninloop/skills/syncing-claude-md/SKILL.md
+++ b/plugins/humaninloop/skills/syncing-claude-md/SKILL.md
@@ -1,13 +1,41 @@
 ---
 name: syncing-claude-md
-description: This skill should be used when the user asks to "sync CLAUDE.md", "update agent instructions", "propagate constitution changes", or mentions "CLAUDE.md sync", "agent instructions", or "constitution alignment". Ensures CLAUDE.md mirrors constitution sections per explicit mapping rules.
+description: Use when user asks to "sync CLAUDE.md", "update agent instructions", "propagate constitution changes", or mentions "CLAUDE.md sync", "agent instructions", or "constitution alignment".
 ---
 
 # Syncing CLAUDE.md
 
-## Purpose
+## Overview
 
 Ensure CLAUDE.md (the primary AI agent instruction file) remains synchronized with the constitution. CLAUDE.md serves a different audience (AI agents) than the constitution (human governance), so synchronization is selective—specific sections map with explicit sync rules.
+
+## When to Use
+
+- Constitution has been amended (any version bump)
+- New principle added to constitution
+- Principle removed from constitution
+- Quality gate thresholds changed
+- Technology stack updated
+- Governance rules modified
+- User explicitly requests CLAUDE.md sync
+- After running `humaninloop:authoring-constitution` or `humaninloop:brownfield-constitution`
+
+## When NOT to Use
+
+- **Constitution does not exist yet**: Create constitution first with `humaninloop:authoring-constitution`
+- **CLAUDE.md is intentionally project-specific**: Some projects customize CLAUDE.md beyond constitution scope
+- **No mapped sections changed**: If amendment only touches rationale or non-mapped sections, sync may not be needed
+- **Draft constitution not yet ratified**: Wait until constitution is approved before syncing
+
+## Common Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Full duplication | CLAUDE.md becomes constitution copy, loses agent-focused format | Use selective sync per mapping table |
+| Stale sync | CLAUDE.md lags behind constitution, agents use outdated rules | Sync on every constitution version bump |
+| Missing version | No version tracking makes drift undetectable | Always include version footer in CLAUDE.md |
+| Partial sync | Some sections synced, others forgotten | Use validation checklist before completing |
+| Summary drift | Summarization loses enforcement keywords and thresholds | Preserve MUST/SHOULD/MAY and numeric thresholds |
 
 ## Why CLAUDE.md Sync Matters
 
@@ -27,6 +55,20 @@ Ensure CLAUDE.md (the primary AI agent instruction file) remains synchronized wi
 
 If CLAUDE.md diverges from the constitution, AI agents operate with outdated or incorrect guidance, undermining governance.
 
+**Consequences of Drift:**
+- Agents may use deprecated technology choices
+- Quality gates may be bypassed due to outdated thresholds
+- Principles may be violated because agents are unaware of new rules
+- Commit conventions may be inconsistent
+- Code review may miss violations that the constitution now prohibits
+
+**Benefits of Synchronization:**
+- Agents always operate with current governance rules
+- Quality gates are consistently enforced
+- New principles are immediately actionable
+- Version tracking provides audit trail
+- Human and AI guidance remain aligned
+
 ## Mandatory Sync Mapping
 
 The following sections MUST be synchronized:
@@ -44,9 +86,30 @@ The following sections MUST be synchronized:
 
 Two primary sync rules govern how content transfers:
 
-**MUST list all with enforcement**: Principles are summarized but preserve enforcement keywords, metrics, and thresholds. Rationale is omitted.
+### Rule 1: MUST List All With Enforcement
 
-**MUST match exactly**: Tables are copied directly with no summarization.
+Principles are summarized but preserve enforcement keywords, metrics, and thresholds. Rationale is omitted because CLAUDE.md focuses on actionable rules, not justification.
+
+**What to preserve:**
+- RFC 2119 keywords (MUST, SHOULD, MAY, MUST NOT, SHOULD NOT)
+- Numeric thresholds (coverage ≥80%, complexity ≤10)
+- Enforcement mechanisms (CI blocks, code review required)
+- Quality gate commands (`pytest --cov-fail-under=80`)
+
+**What to omit:**
+- Rationale sections (why the rule exists)
+- Historical context
+- Detailed examples (unless critical for understanding)
+
+### Rule 2: MUST Match Exactly
+
+Tables are copied directly with no summarization. This applies to:
+- Technology Stack tables
+- Quality Gates tables
+- Layer Import Rules
+- Project Structure (if present)
+
+**Why exact match:** These sections contain precise configuration that agents must follow exactly. Summarization risks losing critical details like specific tool versions or threshold values.
 
 See [SECTION-TEMPLATES.md](SECTION-TEMPLATES.md) for detailed templates and examples for each sync rule.
 
@@ -54,12 +117,49 @@ See [SECTION-TEMPLATES.md](SECTION-TEMPLATES.md) for detailed templates and exam
 
 The sync process follows six steps:
 
-1. **Read Both Files**: Load constitution and CLAUDE.md
-2. **Extract Mapped Sections**: Locate corresponding sections per mapping
-3. **Identify Gaps**: Create gap report showing drift
-4. **Generate Updates**: Prepare specific changes needed
-5. **Apply Updates**: Update CLAUDE.md with synchronized content
-6. **Validate Alignment**: Verify all mapped sections match
+### Step 1: Read Both Files
+
+Load the constitution and CLAUDE.md. Verify both files exist and are readable. If CLAUDE.md does not exist, create it from the section templates.
+
+### Step 2: Extract Mapped Sections
+
+For each row in the Mandatory Sync Mapping table, locate the corresponding sections in both files. Note any missing sections.
+
+### Step 3: Identify Gaps
+
+Create a gap report documenting drift between files:
+
+```markdown
+## Sync Gap Report
+
+**Constitution Version**: 2.1.0
+**CLAUDE.md Version**: 2.0.0
+
+### Gaps Found
+
+| Section | Constitution | CLAUDE.md | Gap Type |
+|---------|--------------|-----------|----------|
+| Quality Gates | coverage ≥80% | coverage ≥70% | Value mismatch |
+| Principles | 7 principles | 6 principles | Missing content |
+| Version | 2.1.0 | 2.0.0 | Version drift |
+
+### Recommended Actions
+1. Update CLAUDE.md Quality Gates: 70% → 80%
+2. Add Principle VII to Principles Summary
+3. Update version footer to 2.1.0
+```
+
+### Step 4: Generate Updates
+
+Prepare specific changes needed. For each gap, draft the exact text change required. Preview changes before applying.
+
+### Step 5: Apply Updates
+
+Update CLAUDE.md with synchronized content. Apply changes section by section, preserving any CLAUDE.md-specific content not in the mapping.
+
+### Step 6: Validate Alignment
+
+Run the Quick Validation checklist. All items must pass before considering sync complete.
 
 See [SYNC-PATTERNS.md](SYNC-PATTERNS.md) for detailed process steps, validation checklists, and conflict resolution.
 
@@ -67,13 +167,28 @@ See [SYNC-PATTERNS.md](SYNC-PATTERNS.md) for detailed process steps, validation 
 
 CLAUDE.md should include these sections for proper sync:
 
-- **Project Overview**: Brief description
-- **Principles**: Synchronized from constitution Core Principles
-- **Technical Stack**: Exact match from constitution Technology Stack
-- **Quality Gates**: Exact match from constitution Quality Gates
-- **Development Workflow**: From constitution Governance
-- **Project Structure**: If present in constitution
-- **Version Footer**: Version and last synced date
+### Required Sections
+
+| Section | Source | Sync Rule | Notes |
+|---------|--------|-----------|-------|
+| Project Overview | Manual | N/A | Brief description of project purpose |
+| Principles | Constitution Core Principles | List with enforcement | Omit rationale, keep keywords |
+| Technical Stack | Constitution Technology Stack | Exact match | Copy table directly |
+| Quality Gates | Constitution Quality Gates | Exact match | Copy table directly |
+| Development Workflow | Constitution Governance | List with enforcement | Include commit conventions |
+| Version Footer | Constitution version | Exact match | Format: `Version X.Y.Z | Last synced: YYYY-MM-DD` |
+
+### Optional Sections
+
+These sections may exist in CLAUDE.md but are not synchronized from the constitution:
+
+- **Project Structure**: Include if constitution defines directory structure
+- **Architecture**: Include if constitution defines layer rules or import restrictions
+- **IDE Setup**: Project-specific, not from constitution
+- **Local Development**: Project-specific, not from constitution
+- **Troubleshooting**: Project-specific, not from constitution
+
+Optional sections are preserved during sync—they are not deleted or modified.
 
 See [SECTION-TEMPLATES.md](SECTION-TEMPLATES.md) for the complete structure template.
 
@@ -88,15 +203,44 @@ CLAUDE.md synchronization MUST occur when:
 5. **Tech stack changed**: MUST update Technical Stack table
 6. **Governance changed**: MUST update Development Workflow
 
+## Conflict Resolution
+
+When CLAUDE.md contains content that conflicts with the constitution:
+
+### Scenario 1: CLAUDE.md Has Extra Content
+
+CLAUDE.md may contain project-specific sections not in the constitution (e.g., IDE setup, local development tips). These sections are allowed and should be preserved during sync.
+
+**Action:** Keep extra sections. Only update mapped sections.
+
+### Scenario 2: CLAUDE.md Has Different Values
+
+A mapped section in CLAUDE.md contains different values than the constitution (e.g., different coverage threshold).
+
+**Action:** Constitution is authoritative. Overwrite CLAUDE.md with constitution values.
+
+### Scenario 3: Constitution Section Missing
+
+A mapped section exists in CLAUDE.md but not in the constitution.
+
+**Action:** Flag for review. Either add section to constitution or remove from CLAUDE.md.
+
+### Scenario 4: Version Mismatch
+
+CLAUDE.md version does not match constitution version.
+
+**Action:** Always align versions. CLAUDE.md version MUST match constitution version after sync. If constitution is v2.1.0, CLAUDE.md footer must show v2.1.0.
+
 ## Quick Validation
 
 Before completing synchronization, verify:
 
-- [ ] All Core Principles listed with enforcement
-- [ ] Technology Stack table matches exactly
-- [ ] Quality Gates table matches exactly
+- [ ] All Core Principles listed with enforcement keywords preserved
+- [ ] Technology Stack table matches exactly (no omissions)
+- [ ] Quality Gates table matches exactly (thresholds identical)
 - [ ] Version numbers match (constitution = CLAUDE.md)
 - [ ] No contradictions between files
+- [ ] Extra CLAUDE.md sections preserved (not deleted)
 
 See [SYNC-PATTERNS.md](SYNC-PATTERNS.md) for the complete validation checklist.
 
@@ -112,14 +256,17 @@ docs: sync CLAUDE.md with constitution vX.Y.Z
 - Version aligned to X.Y.Z
 ```
 
-## Anti-Patterns
+## Referenced Files
 
-| Anti-Pattern | Problem |
-|--------------|---------|
-| Full duplication | CLAUDE.md becomes constitution copy |
-| Stale sync | CLAUDE.md lags behind constitution |
-| Missing version | No version tracking in CLAUDE.md |
-| Partial sync | Some sections synced, others not |
-| Summary drift | Summarization loses enforcement |
+This skill includes detailed reference documentation:
 
-See [SYNC-PATTERNS.md](SYNC-PATTERNS.md) for detailed anti-patterns and fixes.
+| File | Purpose | When to Use |
+|------|---------|-------------|
+| [SECTION-TEMPLATES.md](SECTION-TEMPLATES.md) | Templates for each CLAUDE.md section | When creating or restructuring CLAUDE.md |
+| [SYNC-PATTERNS.md](SYNC-PATTERNS.md) | Detailed sync patterns, validation checklists, edge cases | When resolving complex sync scenarios |
+
+## Related Skills
+
+- **For constitution authoring**: **OPTIONAL:** Use humaninloop:authoring-constitution before syncing (greenfield)
+- **For brownfield projects**: **OPTIONAL:** Use humaninloop:brownfield-constitution before syncing
+- **For validation**: **OPTIONAL:** Use humaninloop:validation-constitution to verify constitution quality


### PR DESCRIPTION
## Summary

- **analysis-codebase**: Fix description format, add required sections (Overview, When to Use, When NOT to Use, Common Mistakes), replace Anti-Patterns with Related Skills using namespace syntax
- **syncing-claude-md**: Fix description format, add required sections, expand content from ~1,180 to ~1,527 words, add Conflict Resolution section, add Referenced Files section

## Changes

### analysis-codebase
- Fix description to start with "Use when..."
- Add Overview, When to Use, When NOT to Use, Common Mistakes sections
- Replace Anti-Patterns with Related Skills section using namespace syntax and dependency markers

### syncing-claude-md  
- Fix description to start with "Use when..."
- Add Overview, When to Use, When NOT to Use, Common Mistakes sections
- Expand Sync Rules with "What to preserve" and "What to omit" guidance
- Expand Synchronization Process with detailed steps and gap report example
- Add Conflict Resolution section (4 scenarios)
- Add CLAUDE.md Structure tables (Required/Optional sections)
- Add Referenced Files section for clear attribution
- Add Related Skills section with namespace syntax
- Expand word count to meet 1,500-2,000 target

## Test plan

- [ ] Run skill audit on analysis-codebase - should pass with zero critical issues
- [ ] Run skill audit on syncing-claude-md - should pass with zero critical issues
- [ ] Verify both descriptions start with "Use when..."
- [ ] Verify all required sections present (Overview, When to Use, When NOT to Use, Common Mistakes)

🤖 Generated with [Claude Code](https://claude.ai/code)