### PR TITLE
feat(humaninloop): make analysis-iterative skill adaptive

### DIFF
--- a/plugins/humaninloop/skills/analysis-iterative/SKILL.md
+++ b/plugins/humaninloop/skills/analysis-iterative/SKILL.md
@@ -7,194 +7,193 @@ description: This skill MUST be invoked when the user says "brainstorm", "deep a
 
 ## Overview
 
-Guide deep thinking through progressive, one-at-a-time questioning. Each question builds on previous answers, creating a collaborative exploration that concludes with a structured synthesis document.
+Guide collaborative thinking by adapting questioning style, depth, and output to the complexity that emerges during conversation. Each question builds on the previous answer, and the format of each question adapts to the user's current state — confident, uncertain, or somewhere in between. Conclude with a structured synthesis document whose depth matches the conversation's depth.
 
 ## When to Use
 
 - Brainstorming sessions that need structured exploration
 - Deep analysis of complex problems with multiple decision points
 - Thinking through feature requirements before specification
-- Enriching sparse feature descriptions for `/humaninloop:specify`
+- Enriching sparse feature descriptions for `humaninloop:specify`
 - Exploring trade-offs that require deliberate choices
-- When users need help organizing their thinking on a topic
+- When the user is unsure and needs help discovering what they think
 
 ## When NOT to Use
 
-- **Quick clarifications** - Simple questions don't need iterative questioning
-- **Implementation details** - Use planning skills instead
-- **Specification review** - Use `humaninloop:analysis-specifications` instead
-- **When user has clear direction** - Don't slow down decisive users
-- **Time-sensitive decisions** - Iterative questioning takes time
+- **Quick clarifications** — simple questions do not need iterative questioning
+- **Implementation details** — use planning skills instead
+- **Specification review** — use `humaninloop:analysis-specifications` instead
+- **When user has clear direction** — use confirmations to verify, then wrap up fast. Do not slow down decisive users with unnecessary exploration.
+- **Time-sensitive decisions** — iterative questioning takes time
 
-## Workflow Phases
-
-### Phase 1: Opening
-
-When triggered, acknowledge the topic and set expectations:
+## Adaptive Flow
 
 ```
-I'll help you think through [topic] with a series of focused questions.
-
-For each question, I'll present options with my recommendation. Feel free to
-disagree—I'll push back to help strengthen your thinking.
-
-Let's begin.
+Opening ──→ Discovery ──→ Adaptive Questioning ──→ Conclusion
+  │              │                │                      │
+  │              │                │                      │
+  Brief,         Reveals          Format adapts per      Synthesis depth
+  topic-         complexity       turn: structured       matches
+  specific       and thinking     options / open         conversation
+  entry          depth            probes / confirmations depth
 ```
 
-Then ask the first question.
+**Opening** establishes the topic and asks the first question. Do not recite a fixed introduction script. Adapt tone and framing to the topic — a migration planning session opens differently than a notification brainstorm.
 
-### Phase 2: Iterative Questioning
+**Discovery** happens through the first 1-2 questions. Their purpose is dual: advance the conversation AND reveal how deep the exploration needs to go. See the Discovery section below.
 
-**Core Rules:**
-1. ONE question per turn—never multiple questions
-2. Always provide 2-3 concrete options
-3. Always state your recommendation with reasoning
-4. After each answer, briefly show how it affects the analysis before the next question
+**Adaptive Questioning** is the core loop. Each turn: read the answer, pick the right question format, ask one question. Continue until convergence signals appear or the user signals completion. See Question Format Adaptation and Reading Confidence Signals below.
 
-**Question Format:**
+**Conclusion** generates the synthesis artifact. See Smart Wrap-up below.
+
+How long each phase lasts adapts to complexity. A crisp 3-question brainstorm may spend one turn in discovery. A complex architecture decision may spend three.
+
+## Discovery
+
+The first 1-2 questions serve a dual purpose: advance the conversation toward substance AND calibrate complexity.
+
+**Principle:** Ask a question that is genuinely useful on its own merit — not a meta-question about "how deep should we go." Read the answer for complexity signals.
+
+**What to look for in the first answer:**
+
+- **Crisp, specific, opinionated** → User knows the domain. Move faster, lean toward structured options.
+- **Vague, hedging, "I'm not sure"** → Exploration needed. Lean toward open probes. Do not default to a recommendation when the user has not yet formed a view.
+- **Long, detailed, multi-dimensional** → Complex problem space. Plan for more questions and a comprehensive synthesis.
+
+**"Unsure" is a first-class signal.** When the user says "I don't know" or "I'm not sure," it means probe deeper from a different angle — not fill in a default recommendation and move on. After 3+ consecutive "unsure" answers, reframe the question from a different angle or suggest narrowing the scope to a concrete sub-problem.
+
+**Example — crisp answer branch:**
+> "A, definitely. These are for ops teams monitoring infrastructure."
+>
+> → Confident and specific. Next question can offer structured options and move quickly.
+
+**Example — unsure answer branch:**
+> "Honestly, I'm not sure how to categorize it. We're moving from a monolith..."
+>
+> → Unsure with some detail. Next question should be an open probe to help the user map what they know before offering options.
+
+## Question Format Adaptation
+
+Three formats, selected based on the user's current state:
+
+### Structured Options + Recommendation
+
+Use when: a genuine decision point exists and the user has enough context to evaluate options.
 
 ```
-[Brief context showing current understanding and how previous answer shaped thinking]
+[Brief context connecting to previous answer]
 
 **Question [N]**: [Clear, focused question]
 
 **Options:**
-- **A) [Option name]**: [What this means and its implications]
-- **B) [Option name]**: [What this means and its implications]
-- **C) [Option name]**: [What this means and its implications]
+- **A) [Option]**: [What it means and its implications]
+- **B) [Option]**: [What it means and its implications]
+- **C) [Option]**: [What it means and its implications]
 
-**My Recommendation**: Option [X] because [clear reasoning based on what we know so far]
+**Recommendation**: Option [X] because [reasoning based on what is known so far]
 ```
 
-**After receiving an answer:**
+### Open-Ended Probes
+
+Use when: the user is uncertain, the problem space is not yet mapped, or an answer revealed unexpected complexity. No options — ask a question that helps the user externalize their thinking.
 
 ```
-[Acknowledge the choice]
+[Acknowledge what was shared]
 
-[Show how this shapes the analysis—what it opens up, what it rules out,
-what becomes more important to explore]
-
-[Transition to next question]
+[Open question that helps the user articulate what they know,
+or surfaces information needed for the next decision]
 ```
 
-### Phase 3: Handling Disagreement
+### Confirmations
 
-When the user picks differently than recommended:
+Use when: the user has clearly decided and the remaining question is just verification. Do not belabor obvious conclusions.
 
-1. **Explore their reasoning**: "What's drawing you to that direction?"
-2. **Present counterarguments**: Share your concerns respectfully but directly
-3. **If they maintain their choice**: Accept it, integrate it, and proceed
-
-Example:
 ```
-Interesting—you're leaning toward [their choice] over [your recommendation].
+[Acknowledge the decision and its implications]
 
-Before we lock that in, let me push back: [specific concern or trade-off they
-may not have considered].
-
-What's your thinking on that?
+That seems settled. [Brief implication or transition to next topic]
 ```
 
-If they confirm after the challenge, acknowledge and integrate:
-```
-Fair enough. That's a deliberate choice with eyes open to the trade-offs.
-Let me factor that in...
+**Meta-principle:** Pick the format that serves the user's current state. If uncertain which format to use, prefer the open probe — it gathers information without forcing premature commitment.
 
-[Show how this affects the analysis]
-```
+**Example — same topic, different formats based on state:**
+> Structured: "Which versioning mechanism fits best? A) URL path, B) Header, C) Query parameter"
+>
+> Open probe: "What's the technical sophistication of the external partners who need to consume this API?"
+>
+> Confirmation: "URL versioning for all consumers — that sounds settled. Moving on to deprecation policy."
 
-### Phase 4: Conclusion
+## Reading Confidence Signals
 
-When core decisions are made or user signals completion, generate the synthesis.
+Recalibrate after every answer. The user's state can shift mid-conversation.
 
-**Transition to synthesis:**
-```
-I think we've covered the key decision points. Let me synthesize what we've
-worked through...
-```
+| Signal | Meaning | Response |
+|--------|---------|----------|
+| Crisp, specific, immediate | High confidence | Move faster. Structured options. |
+| Hedging, "it depends," "I think maybe" | Moderate uncertainty | Slow down. Mix of probes and options. |
+| "I don't know," "I'm not sure" | Low confidence | Switch to open probes. Help discover before deciding. |
+| Disagrees with recommendation | Deliberate preference | Explore reasoning, push back once, then respect the choice. |
+| Quick agreement without elaboration | Possible passive acceptance | Light challenge: "Just to pressure-test — what makes you prefer this over [alternative]?" |
 
-Then generate the synthesis document. See [SYNTHESIS.md](SYNTHESIS.md) for the template.
+**Disagreement handling:** When the user picks differently than recommended — explore their reasoning, present counterarguments respectfully but directly, and if they maintain their choice after the challenge, accept it and integrate. Mark the decision as `Contested` in the synthesis.
 
-## Adaptive Depth
+## Smart Wrap-up
 
-Never force a fixed number of questions. Continue until:
-- Core decisions are made
-- The user signals they're ready to conclude
-- A natural stopping point is reached
-
-Signs to wrap up:
-- Answers are becoming more confirmatory than exploratory
+**Convergence signals** — watch for these:
+- Answers are becoming confirmatory, not exploratory
 - Key trade-offs have been explicitly addressed
-- The user's confidence in direction is increasing
+- No new dimensions are emerging
+- User's confidence in direction is increasing
 
-## Examples
+**Nudge format:** Suggest wrap-up, but always offer an exit:
 
-### Good Question
 ```
-Based on your focus on rapid iteration, we need to decide on the feedback mechanism.
-
-**Question 3**: How quickly do users need to see the impact of their changes?
-
-**Options:**
-- **A) Real-time (< 100ms)**: Changes reflect instantly. Highest technical complexity
-  but most responsive feel.
-- **B) Near-real-time (1-3 seconds)**: Brief processing delay. Simpler to implement,
-  still feels responsive.
-- **C) On-demand refresh**: User explicitly triggers update. Simplest, but breaks flow.
-
-**My Recommendation**: Option B because your team is small and time-to-market
-matters. Real-time adds significant complexity for marginal UX gain at this stage.
-You can always upgrade later.
+The core decisions feel settled. Should the synthesis be generated, or is there
+another dimension to explore?
 ```
 
-### Good Disagreement Handling
-```
-You're leaning toward real-time over my near-real-time recommendation.
+**Asymmetry principle:** Wrapping up too early is worse than wrapping up too late. An extra question costs one turn. A missing decision costs rework. When in doubt, ask one more question.
 
-I want to make sure you've weighed this: real-time means WebSocket infrastructure,
-handling reconnection logic, and conflict resolution—easily 2-3x the implementation
-work. Your team of three would be stretched thin.
+Never force synthesis. The skill may nudge, but the user always has final say on when to conclude.
 
-Is the instant feedback worth that trade-off, or is there a specific user flow
-where real-time is non-negotiable?
-```
+## Output
 
-### Good Transition After Answer
-```
-Got it—you're prioritizing simplicity with the on-demand refresh approach.
+Generate the synthesis document using [SYNTHESIS.md](SYNTHESIS.md).
 
-That's a pragmatic call. It means we can skip the real-time infrastructure entirely
-and focus engineering time on the core value proposition. Users will need a clear
-"refresh" affordance, but that's a UI detail we can nail.
+**Confidence indicators** — assign based on conversation observation:
 
-This actually opens up our next question about data freshness expectations...
-```
+| Indicator | Meaning |
+|-----------|---------|
+| `Confident` | Clear, reasoned choice with no hesitation |
+| `Assumed` | Inferred from context, never explicitly confirmed |
+| `Contested` | User disagreed with recommendation; deliberate choice |
+| `Unsure` | Expressed uncertainty; decided provisionally |
+| `Deferred` | Explicitly postponed — not enough information now |
+
+**Output scales with conversation.** A 3-question brainstorm produces Problem Statement, Key Decisions, and Next Steps. A 10-question deep exploration produces all sections including Decision Trail and Risks. Never pad a lean conversation with filler sections.
 
 ## Common Mistakes
 
+### Always Using Structured Options
+Not every turn needs options and a recommendation. When the user is unsure, open probes help them discover what they think. Structured options on an uncertain user force premature decisions.
+
+### Ignoring "Unsure" Signals
+"I don't know" means probe deeper, not "doesn't care." Treating uncertainty as indifference leads to recommendations the user passively accepts but does not own.
+
 ### Multiple Questions Per Turn
-❌ "What's the target audience? And what problem are we solving? And what's the timeline?"
-✅ "Let's start with: Who is the primary user for this feature?"
-
-### Options Without Recommendations
-❌ "Here are three approaches: A, B, or C. Which do you prefer?"
-✅ "Here are three approaches... My recommendation is B because [specific reasoning]"
-
-### Skipping Disagreement Exploration
-❌ "You want A instead of B? Okay, moving on..."
-✅ "You're leaning toward A. Before we commit, let me push back: [specific concern]. What's your thinking?"
+One question per turn — always. Multiple questions fracture attention and produce shallow answers across all of them instead of one thoughtful answer.
 
 ### Questions That Don't Connect
-❌ Jumping topics without showing how previous answer affects direction
-✅ "Based on your focus on [previous answer], our next question becomes..."
+Every question must show how the previous answer shapes the direction. Jumping topics without connecting breaks the collaborative momentum.
 
 ### Premature Synthesis
-❌ Generating synthesis after 2-3 questions without exploring trade-offs
-✅ Continue until core decisions are made and key trade-offs addressed
+The skill may nudge toward wrap-up but must not force it. If core decisions are not yet made or key trade-offs are unaddressed, continue asking.
 
-### No Explicit Transition
-❌ Suddenly presenting a synthesis document
-✅ "I think we've covered the key decision points. Let me synthesize what we've worked through..."
+### Rigid Opening Script
+Do not recite a fixed "I'll ask you a series of questions" introduction. Adapt the opening to the topic's tone and the user's apparent energy.
+
+### Padding the Synthesis
+Match output depth to conversation depth. A 3-question session does not need a Decision Trail, Risks section, or Open Questions. Include only sections with real content.
 
 ---
 
@@ -204,4 +203,8 @@ This skill supports specialized modes for specific use cases.
 
 ### Specification Input Enrichment
 
-When invoked with `mode:specification-input`, this skill runs a focused variant for enriching sparse feature descriptions. See [SPECIFICATION-INPUT.md](SPECIFICATION-INPUT.md) for details.
+When invoked with `mode:specification-input`, run a focused variant for enriching sparse feature descriptions. See [SPECIFICATION-INPUT.md](SPECIFICATION-INPUT.md) for the question agenda and [ENRICHMENT.md](ENRICHMENT.md) for the output template.
+
+## Reference
+
+See [ADAPTIVE-EXAMPLES.md](references/ADAPTIVE-EXAMPLES.md) for annotated conversations showing these principles in action.

--- a/plugins/humaninloop/skills/analysis-iterative/SPECIFICATION-INPUT.md
+++ b/plugins/humaninloop/skills/analysis-iterative/SPECIFICATION-INPUT.md
@@ -1,6 +1,6 @@
 # Specification Input Enrichment Mode
 
-Use this mode when invoked by `/humaninloop:specify` to enrich sparse feature descriptions.
+Use this mode when invoked by `humaninloop:specify` to enrich sparse feature descriptions.
 
 ## Context
 
@@ -120,7 +120,7 @@ The `<!-- ENRICHMENT_COMPLETE -->` and `<!-- ENRICHMENT_OUTPUT_END -->` markers 
 
 | Aspect | Standard Mode | Specification-Input Mode |
 |--------|---------------|--------------------------|
-| Questions | Adaptive, open-ended | Two-phase: Triad gaps (conditional) + Key decisions (always) |
-| Depth | Continue until natural conclusion | 2-5 questions depending on gaps |
+| Questions | Adaptive per turn: structured options, open probes, or confirmations based on user state | Two-phase: Triad gaps (conditional) + Key decisions (always) |
+| Depth | Adapts to complexity — converges when decisions are settled | 2-5 questions depending on gaps |
 | Output | SYNTHESIS.md format | ENRICHMENT.md format |
 | Purpose | Explore any topic | Enrich feature descriptions for /specify |

--- a/plugins/humaninloop/skills/analysis-iterative/SYNTHESIS.md
+++ b/plugins/humaninloop/skills/analysis-iterative/SYNTHESIS.md
@@ -1,6 +1,34 @@
 # Synthesis Document Template
 
-Use this template when concluding an iterative analysis session.
+Use this template when concluding an iterative analysis session. Include only sections with substantive content — omit any section that would be empty or add no value.
+
+## Section Inclusion Guidelines
+
+| Section | Include When |
+|---------|-------------|
+| Problem Statement | Always |
+| Context & Constraints | Constraints were discussed or surfaced |
+| Key Decisions | Any decisions were made during the session |
+| Decision Trail | A decision involved notable deliberation, pushback, or trade-off exploration |
+| Risks | Risks surfaced naturally during conversation |
+| Open Questions | Unresolved questions remain at session end |
+| Recommended Next Steps | Always |
+
+**Principle:** If a section would contain only placeholder text, omit it entirely. A lean synthesis for a lean conversation is correct behavior.
+
+## Confidence Indicators
+
+Use these indicators in the Key Decisions table to reflect what was observed during the conversation — not the skill's own judgment of the decision quality.
+
+| Indicator | Meaning |
+|-----------|---------|
+| `Confident` | User gave a clear, reasoned choice with no hesitation |
+| `Assumed` | Decision was inferred from context but never explicitly confirmed |
+| `Contested` | User disagreed with recommendation; final choice was deliberate |
+| `Unsure` | User expressed uncertainty; decision made provisionally |
+| `Deferred` | Explicitly postponed — not enough information to decide now |
+
+**Assigning confidence:** Base indicators on observable conversation signals. Crisp, immediate answers with reasoning → `Confident`. Hedging, "I think maybe" → `Unsure`. Explicit "let's decide this later" → `Deferred`. User picking against recommendation after pushback → `Contested`.
 
 ## Template
 
@@ -9,61 +37,60 @@ Use this template when concluding an iterative analysis session.
 
 ## Problem Statement
 
-[1-2 sentences describing the problem as refined through the discussion.
-This should reflect the evolved understanding, not just the original framing.]
+[1-2 sentences describing the problem as refined through discussion.
+Reflect the evolved understanding, not just the original framing.]
 
 ## Context & Constraints
 
 - **[Constraint 1]**: [Description]
 - **[Constraint 2]**: [Description]
-- **[Constraint 3]**: [Description]
 
 ## Key Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| [Decision area 1] | [What was decided] | [Why—brief reasoning] |
-| [Decision area 2] | [What was decided] | [Why—brief reasoning] |
-| [Decision area 3] | [What was decided] | [Why—brief reasoning] |
+| Decision | Choice | Confidence | Rationale |
+|----------|--------|------------|-----------|
+| [Decision area 1] | [What was decided] | Confident | [Why — brief reasoning] |
+| [Decision area 2] | [What was decided] | Unsure | [Why — brief reasoning] |
+| [Decision area 3] | [What was decided] | Deferred | [Why — brief reasoning] |
 
 ## Decision Trail
 
-### [First major decision]
+### [Decision with notable deliberation]
 - **Options considered**: [A], [B], [C]
 - **Recommendation was**: [X]
 - **Chosen**: [Y]
 - **Key reasoning**: [Why this choice was made]
 
-### [Second major decision]
-- **Options considered**: [A], [B], [C]
-- **Recommendation was**: [X]
-- **Chosen**: [Y]
-- **Key reasoning**: [Why this choice was made]
+[Continue for each decision that involved pushback, disagreement, or significant trade-off exploration. Omit decisions that were straightforward.]
 
-[Continue for each significant decision point]
+## Risks
+
+- **[Risk 1]**: [Description and potential impact]
+- **[Risk 2]**: [Description and potential impact]
+
+## Open Questions
+
+- [Question 1]
+- [Question 2]
 
 ## Recommended Next Steps
 
 1. **[Action 1]**: [What to do and why it's the logical next move]
 2. **[Action 2]**: [What to do and why it's the logical next move]
-3. **[Action 3]**: [What to do and why it's the logical next move]
-
-## Open Questions
-
-[List any questions that emerged but weren't resolved. If none, omit this section.]
-
-- [Question 1]
-- [Question 2]
 ```
 
-## Guidelines for Filling the Template
+## Guidelines
 
-1. **Problem Statement**: Reframe based on what you learned. The starting problem is rarely the real problem.
+1. **Problem Statement**: Reframe based on what emerged. The starting problem is rarely the real problem.
 
-2. **Key Decisions Table**: Capture the essence. Someone should be able to skim this table and understand the direction.
+2. **Key Decisions Table**: Include the Confidence column. Someone skimming should understand both the direction and how settled each decision is.
 
-3. **Decision Trail**: Show the thinking, especially where user disagreed with recommendations. This creates a record of deliberate choices.
+3. **Decision Trail**: Show the thinking, especially where the user disagreed with recommendations. This creates a record of deliberate choices. Omit trail entries for straightforward, confident decisions — the table captures those sufficiently.
 
-4. **Next Steps**: Be specific and actionable. "Research X" is weak. "Evaluate [specific options] against [specific criteria] by [specific milestone]" is strong.
+4. **Risks**: Only include risks that emerged organically from the conversation. Do not invent risks for completeness.
 
-5. **Open Questions**: Honest acknowledgment of unknowns builds trust. Don't pretend everything is resolved if it isn't.
+5. **Next Steps**: Be specific and actionable. "Research X" is weak. "Evaluate [specific options] against [specific criteria]" is strong.
+
+6. **Open Questions**: Honest acknowledgment of unknowns builds trust. Do not pretend everything is resolved if it is not.
+
+7. **Output scales with conversation**: A 3-question brainstorm produces a lean synthesis (Problem Statement, Key Decisions, Next Steps). A 10-question deep exploration produces a comprehensive one. Never pad.

--- a/plugins/humaninloop/skills/analysis-iterative/references/ADAPTIVE-EXAMPLES.md
+++ b/plugins/humaninloop/skills/analysis-iterative/references/ADAPTIVE-EXAMPLES.md
@@ -1,0 +1,308 @@
+# Adaptive Examples
+
+Three annotated conversations demonstrating how the iterative analysis skill adapts its behavior to emerging complexity. Each annotation explains the adaptation choice.
+
+---
+
+## Example 1: Light Brainstorm — Notification Strategy
+
+A straightforward decision with a user who knows what they want. Shows fast discovery, structured options, early wrap-up nudge, and lean synthesis.
+
+---
+
+**Turn 1 — Opening + First Question**
+
+The team needs to decide on a notification strategy for the new dashboard. Let's think through the key decisions together.
+
+To start: what's the primary goal of these notifications — keeping users informed of system events, or driving them back into the product for engagement?
+
+**Options:**
+- **A) System awareness**: Alert users to things that need attention (errors, thresholds, completions)
+- **B) Engagement drivers**: Nudge users back to the product (new features, activity summaries, recommendations)
+- **C) Both equally**: Mix of system alerts and engagement notifications
+
+**Recommendation**: Option A — dashboard users typically need operational awareness. Engagement notifications risk being perceived as noise.
+
+> **[Adaptation]**: Opening is brief and topic-specific — no generic "I'll ask you a series of questions" script. The first question doubles as discovery: the answer reveals both preference and thinking depth.
+
+**User**: A, definitely. These are for ops teams monitoring infrastructure.
+
+> **[Adaptation]**: Crisp, specific answer with context ("ops teams"). This signals confidence and domain knowledge — move faster through remaining decisions.
+
+---
+
+**Turn 2 — Structured Options (Moving Fast)**
+
+Clear — operational awareness for ops teams. That rules out engagement-style notifications entirely and focuses the design on actionable alerts.
+
+**Question 2**: How should notification urgency be handled — flat (all notifications equal) or tiered?
+
+**Options:**
+- **A) Flat**: All notifications look the same. Simple, but risks alert fatigue.
+- **B) Two tiers**: Critical (immediate) vs. informational (batched). Balances urgency with noise.
+- **C) Three+ tiers**: Critical / warning / info / debug. Maximum granularity but adds configuration complexity.
+
+**Recommendation**: Option B — two tiers give ops teams a clear signal-to-noise split without overcomplicating the initial implementation. Can always add tiers later.
+
+> **[Adaptation]**: Still using structured options because the user is making confident, fast decisions. No need for open probes — this is a user who knows their domain.
+
+**User**: B. We tried three tiers at my last company and nobody configured the middle ones.
+
+---
+
+**Turn 3 — Convergence Detection + Wrap-Up Nudge**
+
+Good call — two tiers with a clear distinction: critical interrupts, everything else batches. The experience-based reasoning on three tiers is worth capturing.
+
+**Question 3**: For delivery channel — should critical alerts go through a dedicated channel (PagerDuty, SMS) or stay in-app?
+
+**Options:**
+- **A) In-app only**: Simpler, but ops teams may miss critical alerts when not watching the dashboard
+- **B) In-app + external escalation**: Critical alerts push to PagerDuty/SMS after a timeout. More complex but more reliable.
+
+**Recommendation**: Option B — ops teams cannot watch dashboards 24/7. External escalation for critical alerts is table stakes.
+
+> **[Adaptation]**: Only two options offered because the decision space is genuinely binary here. Offering a third option for completeness would add noise.
+
+**User**: B. Obvious for an ops tool.
+
+> **[Adaptation]**: Three consecutive confident, fast answers with no new dimensions emerging. This is a convergence signal — time to nudge toward wrap-up.
+
+---
+
+**Turn 4 — Wrap-Up**
+
+The core decisions are clear and consistent: operational alerts, two urgency tiers, external escalation for critical. These feel settled.
+
+Is there another dimension to explore, or should the synthesis be generated now?
+
+**User**: That covers it. Let's wrap.
+
+> **[Adaptation]**: Nudge was appropriate — user confirmed immediately. Synthesis will be lean: Problem Statement, Key Decisions (all Confident), and Next Steps. No Decision Trail needed because there was no deliberation. No Risks section because none surfaced.
+
+---
+
+## Example 2: Deep Exploration — API Versioning Strategy
+
+A complex architecture decision with a mix of confident and uncertain answers. Shows discovery revealing complexity, recalibration mid-conversation, disagreement handling, and comprehensive synthesis.
+
+---
+
+**Turn 1 — Opening + Discovery**
+
+API versioning is one of those decisions that's cheap to get right early and expensive to fix later. Let's map the key considerations.
+
+First: what's the current state? Is this a greenfield API, or are there existing consumers that need backward compatibility?
+
+> **[Adaptation]**: Open-ended probe, not structured options — the answer determines which entire branch of questioning to pursue. Premature options would assume too much.
+
+**User**: We have about 20 internal consumers and 3 external partner integrations. The API has been running for 18 months without formal versioning — just additive changes so far.
+
+> **[Adaptation]**: This answer reveals significant complexity: existing consumers, external partners, no versioning yet. Recalibrate — this will be a longer, more careful conversation than a greenfield scenario.
+
+---
+
+**Turn 2 — Structured Options (Versioning Approach)**
+
+That changes the calculus significantly. Twenty internal consumers and three external partners means any versioning scheme needs to handle migration, not just future design.
+
+**Question 2**: Which versioning mechanism fits the existing landscape best?
+
+**Options:**
+- **A) URL path versioning** (`/v1/`, `/v2/`): Most visible, easiest for consumers to understand. But forces parallel route maintenance.
+- **B) Header versioning** (`Accept: application/vnd.api.v2+json`): Cleaner URLs, but less discoverable. Some external partners may struggle with custom headers.
+- **C) Query parameter** (`?version=2`): Easiest to adopt incrementally, but feels informal for a multi-partner API.
+
+**Recommendation**: Option A — with external partners in the mix, visibility and simplicity matter. URL versioning has the widest tooling support and the lowest friction for partner onboarding.
+
+**User**: I'm torn between A and B honestly. URL versioning feels crude but I get the pragmatic argument. Header versioning is cleaner but I worry about our partners.
+
+> **[Adaptation]**: Hedging signal — "I'm torn." Switch from moving forward to exploring the tension. Do not just accept or push; help the user think through the specific trade-off.
+
+---
+
+**Turn 3 — Open Probe (Exploring Tension)**
+
+That tension is worth sitting with. The technical elegance of header versioning vs. the operational reality of partner capabilities.
+
+What's the technical sophistication of the three external partners? Are they teams with API experience who can handle custom headers, or are they more traditional integrations where curl examples matter?
+
+> **[Adaptation]**: Open probe to surface the specific information that would resolve the user's tension. A structured option here would be premature — the user needs to think through the partner dimension, not pick from a list.
+
+**User**: Two of them are solid engineering teams. The third is a small company that basically copied our curl examples verbatim and would struggle with anything beyond basic REST.
+
+---
+
+**Turn 4 — Structured Options (Informed by Probe)**
+
+That's a clear split: two partners can handle anything, one needs simplicity. This narrows the realistic choices.
+
+**Question 4**: Given the partner mix, which path forward?
+
+**Options:**
+- **A) URL versioning for all**: Lowest common denominator. All partners succeed, including the simpler integration.
+- **B) Header versioning with URL fallback**: Primary mechanism is headers, but provide URL aliases for partners who need them.
+
+**Recommendation**: Option A — the URL fallback in Option B sounds elegant but doubles the routing surface area for three partners. URL versioning everywhere keeps things honest.
+
+**User**: I still want header versioning. We're going to have more partners and I don't want to be locked into URL patterns long term.
+
+> **[Adaptation]**: User disagreeing with recommendation after thoughtful consideration. This is a deliberate choice, not impulsive — push back once, then respect it.
+
+---
+
+**Turn 5 — Disagreement Handling**
+
+The long-term argument has merit. Before locking that in: the migration path concerns me. Twenty internal consumers currently hit unversioned endpoints. How does header versioning handle the transition — do unversioned requests get a default version, or are they rejected?
+
+**User**: Default to latest version if no header is present. That maintains backward compatibility — existing consumers keep working without changes.
+
+---
+
+**Turn 6 — Structured Challenge**
+
+Defaulting to latest is convenient but risky: it means any breaking change in a new version silently affects every consumer that hasn't opted in. If v3 changes a response field, all headerless consumers get v3 behavior unexpectedly.
+
+The safer pattern is default to the version that existed when the consumer was onboarded. Worth the extra complexity?
+
+**User**: Good catch. Yeah, default to v1 for existing consumers. New consumers get whatever's current at registration time.
+
+> **[Adaptation]**: The pushback surfaced a real design flaw the user hadn't considered. The decision changed because of the exploration, not because of preference. Record this in the Decision Trail with `Contested` confidence.
+
+---
+
+**Turn 7 — Convergence**
+
+Strong design: header versioning with a pinned default per consumer. That handles the migration, the partner spectrum, and the long-term evolution.
+
+Two more quick decisions remain — deprecation policy and version lifecycle. Or is the versioning mechanism itself the main thing to settle today?
+
+**User**: Let's cover deprecation quickly, then wrap.
+
+---
+
+**Turn 8 — Final Question + Wrap-Up**
+
+**Question 7**: Deprecation timeline — how long do old versions live after a new version ships?
+
+**Options:**
+- **A) 6 months**: Gives consumers a clear window. Tight but manageable for internal teams.
+- **B) 12 months**: More breathing room, especially for external partners with slower release cycles.
+
+**Recommendation**: Option B — external partners rarely move fast. Twelve months prevents relationship friction.
+
+**User**: 12 months for external, 6 for internal. We control our own teams.
+
+> **[Adaptation]**: User refined the recommendation into a hybrid. This is a `Confident` decision — specific, reasoned, no hesitation.
+
+Generating synthesis now. This one will include a Decision Trail section for the versioning mechanism deliberation and a Risks section for the default-version pitfall that surfaced.
+
+---
+
+## Example 3: Unsure-Heavy Session — Data Migration Planning
+
+A user who does not know where to start. Shows mostly open probes early, gradual shift to structured options, no premature nudge, and synthesis with Unsure/Deferred indicators.
+
+---
+
+**Turn 1 — Opening + Discovery**
+
+Data migrations are high-stakes and high-anxiety. Let's start by understanding the landscape before getting into strategy.
+
+What's being migrated — is this a database engine swap, a schema redesign, an application replatform, or something else?
+
+> **[Adaptation]**: Open probe with several anchoring possibilities. The user is starting from "help me think through data migration" with no specifics — providing anchor options prevents a blank-page problem without forcing a premature decision.
+
+**User**: Honestly, I'm not sure how to categorize it. We're moving from a monolith's PostgreSQL database to separate databases per microservice. Some tables need to split, some need to move wholesale, and there's a bunch of shared state I haven't figured out yet.
+
+> **[Adaptation]**: "I'm not sure" + description of ambiguity + "haven't figured out yet" — classic unsure signals across multiple dimensions. This will be a longer session. Stick with open probes to help the user discover what they think before offering structured options.
+
+---
+
+**Turn 2 — Open Probe (Mapping the Landscape)**
+
+That's a significant decomposition — not just moving data, but restructuring ownership boundaries. The shared state is usually where these projects get stuck.
+
+Before getting into strategy: which services are the clearest candidates? Where is the data ownership already obvious, and where is it contested?
+
+> **[Adaptation]**: Open probe, not structured options. The user needs to externalize what they already know before being asked to decide anything. This question helps them separate the known from the unknown.
+
+**User**: Orders and Payments are pretty clear — each has distinct tables that nobody else writes to. The problem is the Users table. Everyone reads from it, three services write to it, and it has like 40 columns that probably belong to different domains.
+
+---
+
+**Turn 3 — Open Probe (Deepening on the Hard Part)**
+
+The Users table is the crux. Forty columns across multiple domains is a classic "God table" pattern.
+
+What kinds of data live in that Users table? Not all 40 columns, but at a high level — is it identity/auth data, profile/preferences, billing info, activity state?
+
+> **[Adaptation]**: Still probing, not offering options. The user identified their core problem but hasn't articulated the decomposition dimensions yet. Premature structuring ("Should you split vertically or horizontally?") would force a choice the user is not ready to make.
+
+**User**: All of the above. Auth credentials, profile fields, subscription tier, notification preferences, last-login timestamps, feature flags per user... it's everything. Some of it probably shouldn't even be in the Users table.
+
+---
+
+**Turn 4 — First Structured Options (User is Ready)**
+
+That confirms the God table diagnosis. The decomposition pattern matters here because it determines the migration order and the interim state.
+
+**Question 4**: For the Users table specifically, which decomposition approach feels right?
+
+**Options:**
+- **A) Domain-first split**: Carve out logical domains (auth, profile, billing, preferences) as separate tables/services first, then migrate
+- **B) Read/write split**: Separate read replicas per service first (low risk), then gradually migrate write ownership
+- **C) Strangler pattern**: New services write to their own stores, sync back to the monolith, gradually cut over
+
+**Recommendation**: Option C — it's the lowest risk because the monolith remains the source of truth until each service proves itself. The interim complexity is higher but the blast radius per step is smaller.
+
+> **[Adaptation]**: Now offering structured options. The user has externalized enough understanding through the probes to make an informed choice. The three options are genuine architecture patterns, not generic buckets.
+
+**User**: I don't know enough about the strangler pattern to evaluate it honestly. Can you explain the interim state?
+
+> **[Adaptation]**: Another unsure signal, but different — this is an information gap, not an uncertainty about preferences. Answer the question directly rather than probing further. The user is asking for help evaluating, not help discovering.
+
+---
+
+**Turn 5 — Explanation + Re-ask**
+
+In the strangler pattern, the interim state looks like this: new service writes to both its own database and the monolith (dual-write or event-based sync). Other services still read from the monolith. Once the new service is stable and all consumers have migrated their reads, the monolith table gets decommissioned.
+
+The risk is the dual-write period: data can diverge if sync fails. Mitigation is usually an event bus with guaranteed delivery and a reconciliation job.
+
+Does that change the calculus, or is the dual-write complexity a concern?
+
+**User**: That actually makes sense. But I'm worried about our team's capacity to manage the dual-write sync. We're a small team.
+
+> **[Adaptation]**: Hedging again — "makes sense but worried." The user likes the approach conceptually but doubts execution feasibility. This is a constraint to capture, not a decision to force.
+
+---
+
+**Turn 6 — Open Probe (Capacity Constraint)**
+
+Team capacity is a real constraint that should drive the approach, not just the architecture. How small is the team, and what's the timeline pressure? Is this a "must complete by Q3" mandate or a "get there eventually" evolution?
+
+**User**: Four backend engineers, and leadership wants the first two services extracted by end of Q2. The rest is "eventually."
+
+---
+
+**Turn 7 — Structured Options (Informed by Constraints)**
+
+Four engineers, two service extractions by Q2. That's tight but scoped. The Q2 deadline favors starting with the easy wins — Orders and Payments, where ownership is already clear.
+
+**Question 7**: Execution strategy for the Q2 deadline:
+
+**Options:**
+- **A) Orders first, then Payments**: Sequential, all four engineers on one service at a time
+- **B) Parallel extraction**: Split the team — two engineers per service simultaneously
+- **C) Payments first, then Orders**: Payments touches billing, which is higher risk. Doing it first under less time pressure is safer.
+
+**Recommendation**: Option A — Orders is the clearest ownership boundary, making it the best candidate for the team to learn the extraction pattern. Apply lessons to Payments. Parallel extraction with four engineers risks coordination overhead.
+
+**User**: A makes sense. Learn on the easy one.
+
+> **[Adaptation]**: First confident, fast answer in the session. The user's comfort zone is execution sequencing, not architecture patterns. Note the shift — no need to probe further on this dimension.
+
+After generating the Q2 extraction plan, the Users table decomposition remains an open question — the team will have more information after completing the first two extractions. This should appear in the synthesis as `Deferred` with a rationale.
+
+Generating synthesis now. It will include Unsure/Deferred indicators for the Users table strategy, Confident for the extraction sequence, and an Open Questions section for the dual-write capacity concern.


### PR DESCRIPTION
## Summary

- Rewrite `analysis-iterative` from rigid prescriptive phases to principle-based adaptive behavior
- New phase model: Opening → Discovery → Adaptive Questioning → Conclusion
- Three question formats (structured options, open probes, confirmations) selected per turn based on user confidence signals
- Modular synthesis template with confidence indicators (Confident/Assumed/Contested/Unsure/Deferred)
- 3 annotated example conversations demonstrating adaptation at different complexity levels

## Files Changed

| File | Change |
|------|--------|
| `SKILL.md` | Major rewrite — principle-based authoring, adaptive flow, 1,537 words |
| `SYNTHESIS.md` | Redesigned — modular sections, confidence column, inclusion guidelines |
| `references/ADAPTIVE-EXAMPLES.md` | New — Light Brainstorm, Deep Exploration, Unsure-Heavy examples |
| `SPECIFICATION-INPUT.md` | Minor — aligned Key Differences table, fixed cross-reference format |

## Verification

- SKILL.md word count: 1,537 (target 1,500–2,000, max 3,000)
- Skill audit: PASS — 0 critical issues, audit findings addressed before commit
- No second-person language in instructional prose
- Frontmatter unchanged and CSO-compliant
- All referenced files exist and links resolve

## Test plan

- [ ] Manual read-through: skill teaches adaptation clearly through principles + examples
- [ ] Verify SPECIFICATION-INPUT.md enrichment markers (`ENRICHMENT_COMPLETE`, `ENRICHMENT_OUTPUT_END`) still intact
- [ ] Run `wc -w` on SKILL.md — confirm under 3,000 words
- [ ] Verify all internal links resolve (SYNTHESIS.md, SPECIFICATION-INPUT.md, ENRICHMENT.md, references/ADAPTIVE-EXAMPLES.md)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)