### PR TITLE
docs(humaninloop): refresh agent and skill guidelines (v1.1.0 / v1.3.0)

### DIFF
--- a/docs/AGENT-GUIDELINES.md
+++ b/docs/AGENT-GUIDELINES.md
@@ -1,8 +1,8 @@
 # humaninloop Agent Creation Guidelines
 
-Version: 1.0.0
+Version: 1.1.0
 Status: Draft
-Last Updated: 2026-02-07
+Last Updated: 2026-05-10
 
 ## Document Lineage
 
@@ -15,6 +15,7 @@ This document is derived from brainstorming analysis of humaninloop agent patter
 | [SKILL-GUIDELINES.md](SKILL-GUIDELINES.md) | Anti-leak pattern, testing discipline, validation checklist structure |
 | Official agent-development (Anthropic claude-plugins-official) | `<example>` block triggering, frontmatter schema, system prompt design patterns |
 | humaninloop agent analysis | Persona-first architecture, coupling detection, skill delegation model |
+| 2026-05-10 cross-repo research refresh | Tool restriction tiers, confidence scoring, agent anti-shortcut doctrine, qa-engineer promotion |
 
 ### Divergences from Official Guidelines
 
@@ -45,7 +46,7 @@ A **persona agent** is the primary agent type. It:
 **humaninloop persona agents:**
 - `requirements-analyst` — Senior analyst who transforms ambiguity into clarity
 - `principal-architect` — Senior technical leader who establishes governance standards
-- `qa-engineer` — Senior QA engineer who treats verification as an engineering discipline
+- `qa-engineer` — Senior QA engineer who treats verification as an engineering discipline (promoted from executor in v1.1.0)
 
 All new agents SHOULD be persona agents unless there is a clear reason for another type.
 
@@ -71,9 +72,9 @@ An **executor agent** performs concrete tasks and captures evidence. It:
 - Produces structured evidence for human review
 
 **humaninloop executor agents:**
-- (none currently — qa-engineer was promoted to persona agent)
+- (none currently — `testing-agent` was promoted to `qa-engineer` persona agent in v1.1.0)
 
-Executor agents SHOULD still have a clear identity but the persona is lighter than persona or reviewer agents.
+Executor agents SHOULD still have a clear identity but the persona is lighter than persona or reviewer agents. The empty current list reflects a deliberate trend: when an "executor" accumulates judgment-heavy responsibilities (escalation, evidence interpretation, gate decisions), it MUST be reclassified as a persona agent. Executor remains valid for purely deterministic work.
 
 ---
 
@@ -243,6 +244,23 @@ Persona and reviewer agents SHOULD use `opus`. Executor agents MAY use `sonnet` 
 - Array of tool names to restrict agent access
 - If omitted, agent has access to all tools
 - SHOULD follow principle of least privilege
+
+#### 3.1.3 Tool Restriction Tiers
+
+Observation from claude-plugins-official: production agents consistently restrict tools by responsibility tier. No agent uses `["*"]`. This is a security pattern (predictable surface) AND a clarity pattern (the tools list documents intent).
+
+| Tier | Typical Tools | Agent Type | Example |
+|------|---------------|------------|---------|
+| **Read-only analysis** | `Read`, `Grep`, `Glob`, `Skill` | Reviewers, auditors | `skill-auditor`, `code-reviewer` |
+| **Write-capable authoring** | Read-only tier + `Write`, `Edit` | Persona authors | `requirements-analyst`, `principal-architect` |
+| **Execution-capable** | Write-capable tier + `Bash` | Executors, testing | `qa-engineer` |
+| **Full surface** | omit `tools` field | Orchestration only | (none in humaninloop — orchestration belongs to supervisors) |
+
+Rules:
+- Reviewer agents MUST restrict to read-only tools unless they emit reports via Write
+- Executor agents that run commands MUST include `Bash` in `tools` rather than relying on the default
+- Agents that delegate to skills MUST include `Skill` in their tools list
+- An agent MUST NOT request more tools than its responsibilities require — this prevents scope creep at the architectural layer
 
 ### 3.2 Body Content
 
@@ -558,6 +576,45 @@ If the answer is no, the agent has coupling leaks.
 | Sequencing knowledge | Supervisor orchestration logic |
 | Report format templates | Skill |
 
+### 5.5 Agent Anti-Shortcut Doctrine (NEW in v1.1.0)
+
+This is the agent-level analogue of the CSO Anti-Leak Rule in SKILL-GUIDELINES.md §2.1.3.
+
+**The shortcut hazard:** When an agent's `description` field summarizes the agent's *workflow* or *output format*, the parent agent invoking it tends to act from the description summary instead of dispatching to the agent. The parent reasons: "I already know what this agent does — I can just do that step myself." The agent gets bypassed; the persona never engages.
+
+**The rule:** Agent descriptions MUST describe *triggering conditions* (when this agent should fire) and *what the agent IS* (role, expertise). They MUST NOT describe *what the agent does step-by-step* or *what artifacts it produces*.
+
+```yaml
+# ❌ FORBIDDEN: Workflow-summary description (causes bypass)
+description: |
+  Reviews specs for completeness, identifies gaps, generates clarifying
+  questions, produces a gap report with severity levels, then loops with
+  the requirements-analyst until all gaps are resolved.
+
+# ❌ FORBIDDEN: Output-format description (causes bypass)
+description: |
+  Produces a markdown report with sections: Critical Gaps, Important Gaps,
+  Minor Gaps, and a verdict (APPROVE / REVISE / REJECT).
+
+# ✅ CORRECT: Role + triggers (forces dispatch)
+description: |
+  Adversarial reviewer who stress-tests specifications by hunting gaps,
+  challenging assumptions, and identifying edge cases.
+
+  <example>
+  Context: User has a spec they want reviewed before planning
+  user: "Can you review this spec for gaps before we start planning?"
+  assistant: "I'll use the devils-advocate to stress-test the specification."
+  <commentary>
+  Spec review request triggers adversarial review.
+  </commentary>
+  </example>
+```
+
+**Test for compliance:** Read the description in isolation. Could a parent agent reproduce the agent's output by following only the description? If yes, the description leaks process — strip it back to role + triggers.
+
+**Why it matters:** Personas are behavioral assets. They only engage when invoked. A description that lets the parent shortcut the dispatch is a description that destroys the agent's value proposition.
+
 ---
 
 ## 6. Testing Requirements
@@ -627,6 +684,33 @@ Before shipping, verify the agent passes the reusability test (Section 5.3):
 2. Flag any reference to specific phases, file paths, sibling agents, context schemas, or sequencing
 3. Each flag is a coupling leak that MUST be resolved
 
+### 6.5 Confidence Scoring for Reviewer Agents (NEW in v1.1.0)
+
+Pattern observed in `claude-plugins-official/feature-dev/agents/code-reviewer.md`: reviewer agents emit findings with a confidence score, and only report findings ≥ a threshold. This reduces false-positive noise — the dominant failure mode of reviewer agents.
+
+**Requirement:** All reviewer agents SHOULD assign a 0-100 confidence score to each finding and document the reporting threshold.
+
+```markdown
+## How You Score Findings
+
+Every finding you emit MUST carry a confidence score (0-100) and a severity:
+
+| Confidence | Meaning | Action |
+|------------|---------|--------|
+| 90-100 | Definitive — verifiable against the artifact | Always report |
+| 80-89  | Strong evidence — defensible in code review | Report |
+| 60-79  | Probable — would need a follow-up question to confirm | Report only if Critical severity |
+| < 60   | Speculative — not enough evidence | Do not report |
+
+You MUST NOT report findings below 80 confidence at Important or Minor severity.
+This is your anti-rubber-stamp counterpart: just as you must not under-report,
+you must also not over-report. Noise destroys reviewer credibility.
+```
+
+**Why it matters:** Reviewer agents have two failure modes — rubber-stamping (under-reporting) and crying wolf (over-reporting). Anti-rubber-stamp guidance addresses the first; confidence scoring addresses the second. A reviewer that emits 40 findings of which 5 are real damages trust as much as one that emits 0 findings on a broken artifact.
+
+**Calibration:** During testing, capture each finding's score and verify post-hoc whether it was real. Tune thresholds until precision (real / reported) is ≥ 0.8 at the Important tier.
+
 ---
 
 ## 7. Validation Checklist
@@ -685,11 +769,26 @@ Before shipping any agent, verify:
 - [ ] Adversarial calibration included (no rubber-stamping)
 - [ ] Severity classification guidance
 - [ ] "What You Hunt For" section
+- [ ] Confidence scoring with threshold documented (NEW v1.1.0 — see Section 6.5)
 
 **Executor agents:**
 - [ ] Evidence capture rules defined
 - [ ] Escalation rules defined
 - [ ] Model choice justified (if not `opus`)
+- [ ] Reclassification check: any judgment-heavy responsibilities → promote to persona agent (NEW v1.1.0)
+
+### 7.8 Tool Restriction (MUST — NEW v1.1.0)
+
+- [ ] `tools` field present and matches one of the four tiers (Section 3.1.3)
+- [ ] No agent uses `["*"]` or omits `tools` unless responsibility genuinely requires full surface
+- [ ] Reviewer agents restricted to read-only tools (+ `Write` only if emitting reports)
+- [ ] Agents with `skills` include `Skill` in `tools`
+
+### 7.9 Anti-Shortcut (MUST — NEW v1.1.0)
+
+- [ ] Description describes role + triggers, not workflow steps
+- [ ] Description describes WHAT the agent IS, not WHAT it produces
+- [ ] Compliance test passed: parent agent cannot reproduce the work from description alone (Section 5.5)
 
 ### 7.7 Word Count (SHOULD)
 
@@ -962,6 +1061,20 @@ Write outputs to the locations specified in your instructions.
 ---
 
 ## Changelog
+
+### Version 1.1.0 (2026-05-10)
+- **Foundation:** 2026-05-10 cross-repo research refresh (private experiments repo)
+- **Foundation:** human-in-loop release 3.3.2 (qa-engineer promotion)
+- **Foundation:** Refresh research across claude-plugins-official, agent-skills, superpowers
+- Key additions:
+  - **Section 3.1.3 — Tool Restriction Tiers:** Four-tier responsibility model (read-only / write-capable / execution-capable / full surface) with explicit rules. Pattern observed across all production agents in claude-plugins-official.
+  - **Section 5.5 — Agent Anti-Shortcut Doctrine:** Agent-level analogue of CSO Anti-Leak Rule — descriptions that summarize workflow cause parent agents to bypass the dispatch.
+  - **Section 6.5 — Confidence Scoring for Reviewer Agents:** 0-100 confidence scoring with threshold (≥80 for Important/Minor) to address the over-reporting failure mode. Pattern from `claude-plugins-official/feature-dev/agents/code-reviewer.md`.
+  - **Section 7.8, 7.9 — Validation checklist additions** for the new requirements.
+- Updates from upstream human-in-loop:
+  - `qa-engineer` promoted from executor to persona agent
+  - Executor list now empty by design — reflects trend that judgment-heavy work belongs to persona agents
+  - `testing-agent` references replaced with `qa-engineer`
 
 ### Version 1.0.0 (2026-02-07)
 - Initial draft

--- a/docs/SKILL-GUIDELINES.md
+++ b/docs/SKILL-GUIDELINES.md
@@ -1,8 +1,8 @@
 # humaninloop Skill Creation Guidelines
 
-Version: 1.2.0
+Version: 1.3.0
 Status: Draft
-Last Updated: 2026-02-05
+Last Updated: 2026-05-10
 
 ## Document Lineage
 
@@ -12,23 +12,12 @@ This document is derived from comparative analyses of skill authoring approaches
 
 | Analysis | Key Contributions |
 |----------|-------------------|
-| skill-development vs writing-skills comparative analysis | CSO anti-leak pattern, TDD for documentation, anti-rationalization framework, word count targets |
+| skill-development vs writing-skills comparative analysis (2026-01-25) | CSO anti-leak pattern, TDD for documentation, anti-rationalization framework, word count targets |
+| 2026-05-10 cross-repo research refresh | Knowledge-Skill classification, two-tier validation, runtime-aware paths, token-budget framing |
 
-### Framework
+### How These Guidelines Evolve
 
-To propose changes to these guidelines:
-
-1. Conduct a comparative analysis following the framework
-2. Document findings in `docs/comparative-analyses/YYYY-MM-DD-source1-vs-source2/`
-3. Update this document with new requirements, citing the analysis
-
-### Pending Analyses
-
-Future analyses that may update these guidelines:
-
-- [ ] humaninloop workflow skills vs official plugin-dev patterns
-- [ ] Pressure testing methodology comparison
-- [ ] Agent-skills (Vercel) patterns for technique skills
+Changes to this document should be backed by evidence — comparative analysis of similar guidance in other projects, pressure-test results, or audits of existing skills. Cite the evidence in the changelog entry alongside any new MUST/SHOULD requirement.
 
 ---
 
@@ -72,6 +61,41 @@ A skill is **technique** if it:
 - Teaches a method or pattern
 - Can be applied or not based on context
 - Success is measurable by outcome, not compliance
+
+#### 1.1.4 Knowledge Skills (NEW in v1.3.0)
+
+A skill is **knowledge** if it:
+- Packages a curated body of normative guidance (rules, patterns, conventions) as a queryable corpus
+- Provides no executable workflow — its value is the rule set itself
+- Is referenced by name from other skills/agents to avoid duplication
+- Typically organizes content as one-rule-per-file under `references/` for selective loading
+
+**Pattern observed in `agent-skills/skills/react-best-practices/`:** 74 individual rule files in `rules/`, each with a fixed schema (title, explanation, bad+good examples, impact level), indexed from a lean `SKILL.md`. The skill *is* the documentation, not a tool to execute.
+
+**When to use Knowledge Skills:**
+- Cross-cutting guidance referenced by many other skills (e.g., naming conventions, security patterns, framework idioms)
+- Bodies of guidance large enough that inlining everywhere would burn context
+- Rule sets that need to be machine-extractable (e.g., for IDE integration, lint rule generation)
+
+**Knowledge Skill structure:**
+
+```
+knowledge-skill-name/
+├── SKILL.md            (lean — describes scope + how to query)
+├── rules/              (one rule per file, identical schema)
+│   ├── rule-001-naming.md
+│   ├── rule-002-error-handling.md
+│   └── ...
+├── _sections.md        (index/router for the rules)
+└── metadata.json       (optional — for machine consumers)
+```
+
+**Distinction from Reference Skills:** Reference skills give *information when asked*; Knowledge skills give *normative guidance to apply*. A reference skill answers "what is X?"; a knowledge skill answers "how SHOULD I do X?".
+
+**Validation requirements (additional to Section 8):**
+- Each rule MUST follow the same schema (consistent for machine parsing)
+- The SKILL.md MUST cap at <500 lines and reference rules by name, not inline content
+- A `metadata.json` MAY accompany SKILL.md when machine consumers (CI lints, IDE extensions) need structured access
 
 ---
 
@@ -188,14 +212,21 @@ description: This skill MUST be invoked when the user says "setup project",
 
 | Content | Target | Maximum |
 |---------|--------|---------|
-| SKILL.md body | 1,500-2,000 words | 3,000 words |
+| Frequently-loaded skills (SKILL.md body) | <200 words total | 500 words |
+| Standard skills (SKILL.md body) | 1,500-2,000 words | 3,000 words |
+| Knowledge skills (SKILL.md body) | <500 lines | 800 lines |
 | Metadata (name + description) | ~100 words | 1,088 chars |
 | Reference files | 2,000-5,000 words | Unlimited |
 
 The SKILL.md body:
-- MUST NOT exceed 3,000 words
-- SHOULD target 1,500-2,000 words
+- MUST NOT exceed 3,000 words for standard skills
+- SHOULD target 1,500-2,000 words for standard skills
 - MUST move detailed content to references/ if exceeding targets
+- Knowledge skills (Section 1.1.4) follow line-count budgets, not word-count
+
+**Token budget framing (NEW in v1.3.0):** The context window is a *shared public good* across system prompt, conversation history, sibling skills, and user request. A skill that bloats SKILL.md degrades every other skill's effective budget. Authors MUST treat their skill body as competing for shared space — every paragraph that doesn't earn its keep evicts something from another skill or from the user's actual request.
+
+Concrete rule: before adding ≥100 words to a SKILL.md, ask "could this live in `references/` and be loaded only when needed?" If yes, move it.
 
 #### 2.2.2 Writing Style
 
@@ -323,6 +354,29 @@ Different skill types require different test approaches:
 | Discipline-enforcing | Pressure scenarios, rationalization capture | Compliance under maximum pressure |
 | Reference | Retrieval accuracy, gap testing | Correct information found and applied |
 | Technique | Application scenarios, edge cases | Technique correctly applied to new scenario |
+| Knowledge | Rule-schema validation, retrieval coverage | All rules conform to schema; agent finds the right rule for a query |
+
+### 3.6 Two-Tier Validation (NEW in v1.3.0)
+
+Pattern from `agent-skills/packages/react-best-practices-build/`: skills should pass two distinct validation layers before shipping.
+
+**Tier 1 — Structural validation (machine-checkable):**
+- Frontmatter schema (required fields present, types correct, character limits respected)
+- File structure (SKILL.md exists, referenced files exist, references one level deep)
+- Cross-reference integrity (`humaninloop:skill-name` points to a real skill)
+- Description format (RFC 2119 keyword present, no workflow leakage by regex)
+
+Tier 1 SHOULD be enforced by a script (suggested: `scripts/validate-skill.sh`) and SHOULD run in CI.
+
+**Tier 2 — Semantic validation (human or pressure-test):**
+- Description triggers actually fire on the intended user phrasings
+- Body content addresses the rationalizations captured in baseline testing
+- Required sections contain meaningful content (not empty headings)
+- Examples in body actually illustrate the rule they sit under
+
+Tier 2 is the existing TDD pressure-test cycle (Sections 3.1–3.4) plus the audit checklist.
+
+**Why two tiers:** Tier 1 catches mechanical errors that humans miss in review (typos in YAML, broken links, missing fields). Tier 2 catches behavioral failures that scripts can't detect (rationalizations that bypass the rule). Skipping either tier ships a broken skill.
 
 ---
 
@@ -444,6 +498,33 @@ Use when: Complex domain with validation utilities.
 - MUST NOT create deeply nested reference chains
 - SHOULD include table of contents in reference files >100 lines
 - MUST reference all bundled files from SKILL.md body
+
+### 5.5 Runtime-Aware Path Guidance (NEW in v1.3.0)
+
+Pattern observed in `agent-skills/skills/deploy-to-vercel/SKILL.md:227-245`: skills that work across multiple Claude runtimes (Claude Code CLI, Claude.ai web app, sandboxed environments, third-party agent SDKs) MUST avoid hardcoded paths.
+
+| Runtime | Skill discovery path |
+|---------|----------------------|
+| Claude Code CLI (user-installed) | `~/.claude/plugins/<plugin>/skills/<skill>/` |
+| Claude Code CLI (project-local) | `.claude/skills/<skill>/` |
+| Sandboxed agents (e.g., Codex) | `/mnt/skills/<scope>/<skill>/` |
+| Claude Agent SDK | depends on runtime configuration |
+
+When a skill needs to reference its own bundled assets:
+- ✅ Use relative paths from SKILL.md: `./scripts/validate.sh`, `./references/patterns.md`
+- ❌ Never hardcode absolute paths like `/Users/.../skills/...` or `~/.claude/skills/...`
+- ✅ For runtime-specific instructions, document each runtime explicitly under a "Runtime Notes" section
+- ❌ Never assume a single runtime — humaninloop skills target Claude Code CLI primarily but MAY be reused
+
+Example "Runtime Notes" pattern:
+
+```markdown
+## Runtime Notes
+
+- **Claude Code CLI:** Bundled scripts in `./scripts/` are executable directly via `Bash`.
+- **Sandboxed environments:** Scripts may be at `/mnt/skills/humaninloop/<skill>/scripts/`. Check `$SKILL_PATH` env var if available.
+- **Claude Agent SDK:** Skill is invoked programmatically; bundled scripts MAY require explicit path resolution.
+```
 
 ---
 
@@ -647,6 +728,25 @@ Before shipping any skill, verify:
 - [ ] Utilities in scripts/
 - [ ] All resources referenced from SKILL.md
 
+### 8.6 Two-Tier Validation (MUST — NEW v1.3.0)
+
+- [ ] Tier 1 structural validation passes (frontmatter schema, file existence, link integrity)
+- [ ] Tier 2 semantic validation passes (TDD pressure tests + audit checklist)
+- [ ] CI hook for Tier 1 documented (script path noted in SKILL.md or README)
+
+### 8.7 Knowledge Skill Specifics (MUST if Knowledge Skill — NEW v1.3.0)
+
+- [ ] Each rule file follows the same schema (validated by script)
+- [ ] SKILL.md ≤500 lines and references rules by name
+- [ ] `_sections.md` or equivalent index present
+- [ ] `metadata.json` present if machine consumers exist
+
+### 8.8 Runtime-Aware Paths (MUST — NEW v1.3.0)
+
+- [ ] No hardcoded absolute paths in SKILL.md or referenced files
+- [ ] Bundled assets referenced by relative paths (`./scripts/...`)
+- [ ] Runtime Notes section present if skill targets multiple runtimes
+
 ---
 
 ## 9. Enforcement
@@ -772,6 +872,16 @@ Common rationalizations and their counters:
 
 ## Changelog
 
+### Version 1.3.0 (2026-05-10)
+- **Foundation:** 2026-05-10 cross-repo research refresh (private experiments repo)
+- **Foundation:** Refresh research across claude-plugins-official, agent-skills (Vercel), superpowers
+- Key additions:
+  - **Section 1.1.4 — Knowledge Skills:** New skill type for curated rule corpora (rule-per-file, machine-extractable). Pattern from `agent-skills/skills/react-best-practices/` (74 rule files, identical schema).
+  - **Section 2.2.1 — Tiered word counts + token-budget framing:** Adds line-count budgets for knowledge skills and explicit "shared public good" framing for context window economics. Pattern from `superpowers/skills/writing-skills/SKILL.md:213-267`.
+  - **Section 3.6 — Two-Tier Validation:** Distinct structural (machine-checkable) vs semantic (pressure-test) validation layers. Pattern from `agent-skills/packages/react-best-practices-build/`.
+  - **Section 5.5 — Runtime-Aware Path Guidance:** Avoid hardcoded paths; document runtime-specific behavior in a "Runtime Notes" section. Pattern from `agent-skills/skills/deploy-to-vercel/SKILL.md:227-245`.
+  - **Sections 8.6, 8.7, 8.8 — Validation checklist additions** for the new requirements.
+
 ### Version 1.2.0 (2026-02-05)
 - **BREAKING:** Unified RFC 2119 standard for ALL skills
 - Removed invocation classification (user-invoked/agent-invoked/hybrid distinction)
@@ -794,7 +904,7 @@ Common rationalizations and their counters:
 
 ### Version 1.0.0 (2026-01-25)
 - Initial draft
-- **Foundation:** skill-development vs writing-skills comparative analysis
+- **Foundation:** skill-development vs writing-skills comparative analysis (2026-01-25)
 - Key adoptions from analysis:
   - CSO anti-leak pattern (Section 2.1.3) - from Superpowers
   - TDD for documentation (Section 3) - from Superpowers


### PR DESCRIPTION
## Summary

Refresh of [docs/AGENT-GUIDELINES.md](docs/AGENT-GUIDELINES.md) (v1.0.0 → v1.1.0) and [docs/SKILL-GUIDELINES.md](docs/SKILL-GUIDELINES.md) (v1.2.0 → v1.3.0) with patterns surfaced from a fresh comparative read of `claude-plugins-official`, Vercel Labs `agent-skills`, and `superpowers`.

## What's New

### AGENT-GUIDELINES v1.1.0
- **§3.1.3 Tool Restriction Tiers** — four-tier responsibility model (read-only / write-capable / execution-capable / full surface) with explicit rules. Pattern observed across all production agents in `claude-plugins-official`.
- **§5.5 Agent Anti-Shortcut Doctrine** — agent-level analogue of CSO Anti-Leak Rule. Workflow-summary descriptions cause parent agents to bypass dispatch.
- **§6.5 Confidence Scoring for Reviewer Agents** — 0-100 confidence with threshold (≥80 for Important/Minor). Addresses the over-reporting failure mode that prior guidance didn't cover. Pattern from `claude-plugins-official/feature-dev/agents/code-reviewer.md`.
- **qa-engineer** added to persona agent list (was executor in v1.0.0). Executor list now empty by design — reflects trend that judgment-heavy work belongs to persona agents.
- **Validation checklist** additions (§7.6, §7.8, §7.9) to enforce the new requirements.

### SKILL-GUIDELINES v1.3.0
- **§1.1.4 Knowledge Skills** — new 4th classification for curated rule corpora (rule-per-file, machine-extractable schema). Pattern from `agent-skills/skills/react-best-practices/` (74 rule files, identical schema).
- **§2.2.1 Tiered word counts + token-budget framing** — line-count budgets for knowledge skills; explicit "shared public good" framing for context window economics. Pattern from `superpowers/skills/writing-skills`.
- **§3.6 Two-Tier Validation** — distinct structural (machine-checkable, CI-enforceable) vs semantic (pressure-test) validation layers. Pattern from `agent-skills/packages/react-best-practices-build/`.
- **§5.5 Runtime-Aware Path Guidance** — avoid hardcoded paths; document runtime-specific behavior in a Runtime Notes section.
- **Validation checklist** additions (§8.6, §8.7, §8.8).

## What Did NOT Change

- Three-Layer Separation (Agent / Skill / Supervisor) — still load-bearing
- Five Anti-Leak Rules in AGENT-GUIDELINES — still load-bearing
- CSO Anti-Leak Rule in SKILL-GUIDELINES — still load-bearing
- TDD discipline / Iron Law — still load-bearing
- Anti-rationalization framework — still load-bearing
- RFC 2119 description format — still load-bearing, validated by 20+ skill audits

## Cross-Document Coherence

The two updated documents form a coherent system: SKILL-GUIDELINES §3.6 (Two-Tier Validation) parallels AGENT-GUIDELINES §6.5 (Confidence Scoring), and SKILL-GUIDELINES §2.1.3 (CSO Anti-Leak) parallels AGENT-GUIDELINES §5.5 (Agent Anti-Shortcut). No contradictions across the two updated documents; every cross-reference resolves.

## Test Plan

- [ ] Pre-commit hook validates conventional-commits format
- [ ] No broken markdown links in updated docs (verified via grep — all relative links resolve within the repo)
- [ ] CLAUDE.md still references the two doc paths correctly (no path changes)
- [ ] Skill-auditor agent should be updated separately to emit findings in the new audit schema (out of scope for this PR — see follow-up below)

## Follow-Up Work (Out of Scope)

1. Build `scripts/validate-skill-structure.sh` for Tier 1 structural validation (referenced as suggested in SKILL-GUIDELINES §3.6)
2. Update `skill-auditor` agent to emit findings using the new severity/confidence/citation schema
3. Concrete Knowledge Skill exemplar (e.g., naming conventions, security patterns)
4. Decide whether to backfill confidence scoring for the 20 prior PASS audits or grandfather them

🤖 Generated with [Claude Code](https://claude.com/claude-code)